### PR TITLE
Fix execution environment

### DIFF
--- a/extensions/experiences/create_iis/setup.yml
+++ b/extensions/experiences/create_iis/setup.yml
@@ -43,3 +43,5 @@ controller_templates:
     project: Windows Operations / Project
     survey_enabled: true
     survey_spec: "{{ lookup('file', experience.path.replace('setup.yml', '') + 'template_surveys/create_iis.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/experiences/delete_iis/setup.yml
+++ b/extensions/experiences/delete_iis/setup.yml
@@ -43,3 +43,5 @@ controller_templates:
     project: Windows Operations / Project
     survey_enabled: true
     survey_spec: "{{ lookup('file', experience.path.replace('setup.yml', '') + 'template_surveys/delete_iis.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/roles/windows_manage_iis/meta/argument_specs.yml
+++ b/roles/windows_manage_iis/meta/argument_specs.yml
@@ -26,7 +26,6 @@ argument_specs:
         type: int
         description: The network port that the Server will listen on.
         default: 80
-        required: true
       windows_manage_iis_path:
         type: str
         description: The path on disk where the web content will be served from.


### PR DESCRIPTION
Just fixing small errors.

Experience should ask for credentials, we cannot guess correct one - same as for inventory.

Execution environment `apd-ee-25-windows` needs to be used by created job templates.

In argument spec for `windows_manage_iis_port`, the `required: true` clashed with `default` value. We need to remove one.
