### PR TITLE
Fix test_command

### DIFF
--- a/roles/windows_manage_iis/tasks/create.yml
+++ b/roles/windows_manage_iis/tasks/create.yml
@@ -13,7 +13,7 @@
 
 - name: Reboot when Web-Server feature requires it
   ansible.windows.win_reboot:
-    test_command: 'exit (Get-Service -Name Netlogon).Status -ne "Running"'
+    test_command: '(Get-Service -Name Netlogon).Status -ne "Running"'
   when: windows_manage_iis_output.reboot_required
 
 - name: Create site directory structure


### PR DESCRIPTION
The example given for win_reboot test_command is wrong, you don't need the exit at the beginning of the script.