### PR TITLE
Fix AAP job template playbook path

### DIFF
--- a/extensions/patterns/create_iis/setup.yml
+++ b/extensions/patterns/create_iis/setup.yml
@@ -26,7 +26,7 @@ controller_projects:
     scm_clean: 'no'
     scm_delete_on_update: 'no'
     scm_type: git
-    scm_update_on_launch: 'no'
+    scm_update_on_launch: 'yes'
     scm_url: https://github.com/redhat-cop/infra.windows_ops.git
 
 

--- a/extensions/patterns/create_iis/setup.yml
+++ b/extensions/patterns/create_iis/setup.yml
@@ -39,7 +39,7 @@ controller_templates:
       - infra.windows_ops
       - create_iis_pattern
       - run_create_iis
-    playbook: "{{ pattern.path.replace('setup.yml', '') + 'playbooks/run_create_iis.yml' }}"
+    playbook: "extensions/patterns/create_iis/playbooks/run_create_iis.yml"
     project: Windows Operations / Project
     survey_enabled: true
     survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/create_iis.yml') | from_yaml }}"

--- a/extensions/patterns/delete_iis/setup.yml
+++ b/extensions/patterns/delete_iis/setup.yml
@@ -26,7 +26,7 @@ controller_projects:
     scm_clean: 'no'
     scm_delete_on_update: 'no'
     scm_type: git
-    scm_update_on_launch: 'no'
+    scm_update_on_launch: 'yes'
     scm_url: https://github.com/redhat-cop/infra.windows_ops.git
 
 

--- a/extensions/patterns/delete_iis/setup.yml
+++ b/extensions/patterns/delete_iis/setup.yml
@@ -39,7 +39,7 @@ controller_templates:
       - infra.windows_ops
       - delete_iis_pattern
       - run_delete_iis
-    playbook: "{{ pattern.path.replace('setup.yml', '') + 'playbooks/run_delete_iis.yml' }}"
+    playbook: "extensions/patterns/delete_iis/playbooks/run_delete_iis.yml"
     project: Windows Operations / Project
     survey_enabled: true
     survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/delete_iis.yml') | from_yaml }}"


### PR DESCRIPTION
PR configures AAP project to update on launch. It makes debugging easier if you are really using the latest version of your branch, not stale one :)

The AAP job template was not created, because playbook path was invalid from AAP and AAP project point of view. Calculated path was absolute path to playbook (to directory in /tmp, where https://github.com/ansible/ansible-pattern-loader checked out the git code). AAP job template needs path relative to AAP project. We can provide playbook path as a fixed string.