### PR TITLE
Fix only_rules filtering for STIG and CIS roles

### DIFF
--- a/roles/windows_manage_cis/tasks/main.yml
+++ b/roles/windows_manage_cis/tasks/main.yml
@@ -75,7 +75,7 @@
     - "'user_rights_assignment' in windows_manage_cis_categories"
     - >-
       windows_manage_cis_only_rules | length == 0 or
-      windows_manage_cis_only_rules | select('match', '^2\\.2\\.*') | length > 0
+      windows_manage_cis_only_rules | select('match', '^2\.2\.') | list | length > 0
   tags:
     - user_rights_assignment
     - section_2
@@ -87,7 +87,7 @@
     - "'security_options' in windows_manage_cis_categories"
     - >-
       windows_manage_cis_only_rules | length == 0 or
-      windows_manage_cis_only_rules | select('match', '^2\\.3\\.*') | length > 0
+      windows_manage_cis_only_rules | select('match', '^2\.3\.') | list | length > 0
   tags:
     - security_options
     - section_2
@@ -99,7 +99,7 @@
     - "'system_services' in windows_manage_cis_categories"
     - >-
       windows_manage_cis_only_rules | length == 0 or
-      windows_manage_cis_only_rules | select('match', '^5\\.*') | length > 0
+      windows_manage_cis_only_rules | select('match', '^5\.') | list | length > 0
   tags:
     - system_services
     - section_5
@@ -111,7 +111,7 @@
     - "'advanced_audit_policies' in windows_manage_cis_categories"
     - >-
       windows_manage_cis_only_rules | length == 0 or
-      windows_manage_cis_only_rules | select('match', '^17\\.*') | length > 0
+      windows_manage_cis_only_rules | select('match', '^17\.') | list | length > 0
   tags:
     - advanced_audit_policies
     - section_17
@@ -123,7 +123,7 @@
     - "'event_log' in windows_manage_cis_categories"
     - >-
       windows_manage_cis_only_rules | length == 0 or
-      windows_manage_cis_only_rules | select('match', '^17\\.9\\.*') | length > 0
+      windows_manage_cis_only_rules | select('match', '^17\.9\.') | list | length > 0
   tags:
     - event_log
     - section_17
@@ -135,7 +135,7 @@
     - "'administrative_templates' in windows_manage_cis_categories"
     - >-
       windows_manage_cis_only_rules | length == 0 or
-      windows_manage_cis_only_rules | select('match', '^18\\.*') | length > 0
+      windows_manage_cis_only_rules | select('match', '^18\.') | list | length > 0
   tags:
     - administrative_templates
     - registry_settings
@@ -148,7 +148,7 @@
     - "'windows_firewall' in windows_manage_cis_categories"
     - >-
       windows_manage_cis_only_rules | length == 0 or
-      windows_manage_cis_only_rules | select('match', '^9\\.*') | length > 0
+      windows_manage_cis_only_rules | select('match', '^9\.') | list | length > 0
   tags:
     - windows_firewall
     - section_9
@@ -160,7 +160,7 @@
     - "'additional_registry' in windows_manage_cis_categories"
     - >-
       windows_manage_cis_only_rules | length == 0 or
-      windows_manage_cis_only_rules | select('match', '^19\\.*') | length > 0
+      windows_manage_cis_only_rules | select('match', '^19\.') | list | length > 0
   tags:
     - additional_registry
     - section_19

--- a/roles/windows_manage_stig/tasks/account_policies.yml
+++ b/roles/windows_manage_stig/tasks/account_policies.yml
@@ -92,6 +92,8 @@
     value: "{{ item.value }}"
   register: windows_manage_stig_account_current
   loop: "{{ windows_manage_stig_account_policies }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or item.stig_id in windows_manage_stig_only_rules
   check_mode: true # Use check mode to get current values without changing
   tags:
     - account_policies
@@ -122,22 +124,26 @@
 - name: STIG Account Policies | AUDIT | Record compliance results
   ansible.builtin.set_fact:
     windows_manage_stig_results: >-
-      {{ windows_manage_stig_results | default([]) + (windows_manage_stig_account_policies | map('combine', {
-        'rule_section': 'Account Policies',
-        'scored': true,
-        'current_value': windows_manage_stig_account_current.results[ansible_loop.index0].value | default('Not Configured'),
-        'expected_value': item.value,
-        'status': 'PASS' if (windows_manage_stig_account_current.results[ansible_loop.index0].value | string == item.value | string) else 'FAIL',
-        'changed': (windows_manage_stig_account_results.results | selectattr('item.stig_id', 'equalto', item.stig_id) | list | first).changed | default(false),
-        'skip_reason': 'User configured skip' if item.stig_id in windows_manage_stig_skip_rules else '',
-        'check_mode': ansible_check_mode
-      }) | list) }}
+      {{ windows_manage_stig_results | default([]) + [
+        account_policy | combine({
+          'rule_section': 'Account Policies',
+          'scored': true,
+          'current_value': current_value,
+          'expected_value': account_policy.value,
+          'status': ('PASS' if (current_value | string == account_policy.value | string) else 'FAIL'),
+          'changed': changed_status,
+          'skip_reason': ('User configured skip' if account_policy.stig_id in windows_manage_stig_skip_rules else ''),
+          'check_mode': ansible_check_mode
+        })
+      ] }}
   vars:
-    item: "{{ account_policy }}"
+    current_value: "{{ (windows_manage_stig_account_current.results | selectattr('item.stig_id', 'equalto', account_policy.stig_id) | list | first).value | default('Not Configured') }}"
+    changed_status: "{{ (windows_manage_stig_account_results.results | selectattr('item.stig_id', 'equalto', account_policy.stig_id) | list | first).changed | default(false) }}"
   loop: "{{ windows_manage_stig_account_policies }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or account_policy.stig_id in windows_manage_stig_only_rules
   loop_control:
     loop_var: account_policy
-    extended: true
   tags:
     - account_policies
     - compliance

--- a/roles/windows_manage_stig/tasks/audit_policies.yml
+++ b/roles/windows_manage_stig/tasks/audit_policies.yml
@@ -261,6 +261,7 @@
   register: windows_manage_stig_audit_results
   when:
     - item.stig_id not in windows_manage_stig_skip_rules
+    - windows_manage_stig_only_rules | length == 0 or item.stig_id in windows_manage_stig_only_rules
     - windows_manage_stig_audit_current_all.result.audit_policies[item.subcategory] | default('No Auditing') != item.expected
   tags:
     - audit_policies
@@ -273,15 +274,25 @@
 
 - name: STIG Audit Policies | AUDIT | Record all audit policy compliance results (consolidated)
   ansible.builtin.set_fact:
-    windows_manage_stig_results: "{{ windows_manage_stig_results | default([]) + (windows_manage_stig_audit_policies | map('combine', {'rule_section': 'Audit Policies',
-      'scored': true, 'current_value': windows_manage_stig_audit_current_all.result.audit_policies[item.subcategory] | default('No Auditing'), 'expected_value': item.expected,
-      'status': ('PASS' if (windows_manage_stig_audit_current_all.result.audit_policies[item.subcategory] | default('No Auditing') == item.expected) else 'FAIL'),
-      'changed': (windows_manage_stig_audit_results.results | selectattr('item.stig_id', 'equalto', item.stig_id) | list | first).changed | default(false), 'skip_reason':
-      ('User configured skip' if item.stig_id in windows_manage_stig_skip_rules else ('Not applicable - Domain Controller only' if item.dc_only and ansible_facts.get('env_type',
-      '') != 'domain_controller' else '')), 'check_mode': ansible_check_mode}) | list) }}"
+    windows_manage_stig_results: >-
+      {{ windows_manage_stig_results | default([]) + [
+        audit_policy | combine({
+          'rule_section': 'Audit Policies',
+          'scored': true,
+          'current_value': current_audit_value,
+          'expected_value': audit_policy.expected,
+          'status': ('PASS' if (current_audit_value == audit_policy.expected) else 'FAIL'),
+          'changed': changed_status,
+          'skip_reason': ('User configured skip' if audit_policy.stig_id in windows_manage_stig_skip_rules else ('Not applicable - Domain Controller only' if audit_policy.dc_only and ansible_facts.get('env_type', '') != 'domain_controller' else '')),
+          'check_mode': ansible_check_mode
+        })
+      ] }}
   vars:
-    item: "{{ audit_policy }}"
+    current_audit_value: "{{ windows_manage_stig_audit_current_all.result.audit_policies[audit_policy.subcategory] | default('No Auditing') }}"
+    changed_status: "{{ (windows_manage_stig_audit_results.results | selectattr('item.stig_id', 'equalto', audit_policy.stig_id) | list | first).changed | default(false) }}"
   loop: "{{ windows_manage_stig_audit_policies }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or audit_policy.stig_id in windows_manage_stig_only_rules
   loop_control:
     loop_var: audit_policy
   tags:

--- a/roles/windows_manage_stig/tasks/registry_settings.yml
+++ b/roles/windows_manage_stig/tasks/registry_settings.yml
@@ -484,6 +484,8 @@
     name: "{{ item.name }}"
   register: windows_manage_stig_registry_current
   loop: "{{ windows_manage_stig_registry_settings }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or item.stig_id in windows_manage_stig_only_rules
   check_mode: false
   tags:
     - registry_settings
@@ -515,22 +517,26 @@
 - name: STIG Registry Settings | AUDIT | Record compliance results
   ansible.builtin.set_fact:
     windows_manage_stig_results: >-
-      {{ windows_manage_stig_results | default([]) + (windows_manage_stig_registry_settings | map('combine', {
-        'rule_section': 'Registry Settings',
-        'scored': true,
-        'current_value': windows_manage_stig_registry_current.results[ansible_loop.index0].value | default('Not Configured'),
-        'expected_value': item.description,
-        'status': 'PASS' if (windows_manage_stig_registry_current.results[ansible_loop.index0].value | default('') | string == item.data | string) else 'FAIL',
-        'changed': (windows_manage_stig_registry_results.results | selectattr('item.stig_id', 'equalto', item.stig_id) | list | first).changed | default(false),
-        'skip_reason': 'User configured skip' if item.stig_id in windows_manage_stig_skip_rules else '',
-        'check_mode': ansible_check_mode
-      }) | list) }}
+      {{ windows_manage_stig_results | default([]) + [
+        registry_setting | combine({
+          'rule_section': 'Registry Settings',
+          'scored': true,
+          'current_value': current_value,
+          'expected_value': registry_setting.description,
+          'status': ('PASS' if (current_value | string == registry_setting.data | string) else 'FAIL'),
+          'changed': changed_status,
+          'skip_reason': ('User configured skip' if registry_setting.stig_id in windows_manage_stig_skip_rules else ''),
+          'check_mode': ansible_check_mode
+        })
+      ] }}
   vars:
-    item: "{{ registry_setting }}"
+    current_value: "{{ (windows_manage_stig_registry_current.results | selectattr('item.stig_id', 'equalto', registry_setting.stig_id) | list | first).value | default('Not Configured') }}"
+    changed_status: "{{ (windows_manage_stig_registry_results.results | selectattr('item.stig_id', 'equalto', registry_setting.stig_id) | list | first).changed | default(false) }}"
   loop: "{{ windows_manage_stig_registry_settings }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or registry_setting.stig_id in windows_manage_stig_only_rules
   loop_control:
     loop_var: registry_setting
-    extended: true
   tags:
     - registry_settings
     - compliance

--- a/roles/windows_manage_stig/tasks/security_options.yml
+++ b/roles/windows_manage_stig/tasks/security_options.yml
@@ -379,6 +379,8 @@
     name: "{{ item.name }}"
   register: windows_manage_stig_security_registry_current
   loop: "{{ windows_manage_stig_security_options | dict2items | map(attribute='value') | flatten | selectattr('path', 'defined') }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or item.stig_id in windows_manage_stig_only_rules
   check_mode: false
   tags:
     - security_options
@@ -434,19 +436,26 @@
 
 - name: STIG Security Options | AUDIT | Record compliance results
   ansible.builtin.set_fact:
-    windows_manage_stig_results: "{{ windows_manage_stig_results | default([]) + (all_security_options | map('combine', {'rule_section': 'Security Options', 'scored':
-      true, 'current_value': (('Registry: ' + (registry_results[loop.index0].value | default('Not Configured') | string)) if item.path is defined else 'Policy: Applied'),
-      'expected_value': item.description, 'status': ('PASS' if ((item.path is defined and registry_results[loop.index0].value | default('') | string == item.data
-      | string) or (item.method is defined)) else 'FAIL'), 'changed': false, 'skip_reason': 'User configured skip' if item.stig_id in windows_manage_stig_skip_rules
-      else '', 'check_mode': ansible_check_mode}) | list) }}"
+    windows_manage_stig_results: >-
+      {{ windows_manage_stig_results | default([]) + [
+        security_option | combine({
+          'rule_section': 'Security Options',
+          'scored': true,
+          'current_value': (('Registry: ' + (current_reg_value | string)) if security_option.path is defined else 'Policy: Applied'),
+          'expected_value': security_option.description,
+          'status': ('PASS' if ((security_option.path is defined and current_reg_value | string == security_option.data | string) or (security_option.method is defined)) else 'FAIL'),
+          'changed': false,
+          'skip_reason': ('User configured skip' if security_option.stig_id in windows_manage_stig_skip_rules else ''),
+          'check_mode': ansible_check_mode
+        })
+      ] }}
   vars:
-    all_security_options: "{{ windows_manage_stig_security_options | dict2items | map(attribute='value') | flatten }}"
-    registry_results: "{{ windows_manage_stig_security_registry_current.results | default([]) }}"
-    item: "{{ security_option }}"
-  loop: "{{ all_security_options }}"
+    current_reg_value: "{{ (windows_manage_stig_security_registry_current.results | default([]) | selectattr('item.stig_id', 'equalto', security_option.stig_id) | list | first).value | default('Not Configured') }}"
+  loop: "{{ windows_manage_stig_security_options | dict2items | map(attribute='value') | flatten }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or security_option.stig_id in windows_manage_stig_only_rules
   loop_control:
     loop_var: security_option
-    extended: true
   tags:
     - security_options
     - compliance

--- a/roles/windows_manage_stig/tasks/system_services.yml
+++ b/roles/windows_manage_stig/tasks/system_services.yml
@@ -394,6 +394,8 @@
     name: "{{ item.name }}"
   register: windows_manage_stig_services_current
   loop: "{{ all_services }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or item.stig_id in windows_manage_stig_only_rules
   check_mode: false
   failed_when: false # Some services may not exist on all systems
   vars:
@@ -515,28 +517,25 @@
 - name: STIG System Services | AUDIT | Record compliance results
   ansible.builtin.set_fact:
     windows_manage_stig_results: >-
-      {{ windows_manage_stig_results | default([]) +
-        (all_services | map('combine', {
+      {{ windows_manage_stig_results | default([]) + [
+        service | combine({
           'rule_section': 'System Services',
           'scored': true,
-          'current_value': current_state_info.state + ' / ' + current_state_info.start_mode if current_state_info.exists else 'Service not installed',
-          'expected_value': item.description,
-          'status': ('PASS' if (not current_state_info.exists or (current_state_info.state == item.state and current_state_info.start_mode == item.start_mode)) else 'FAIL'),
-          'changed': task_changed,
-          'skip_reason': ('User configured skip' if item.stig_id in windows_manage_stig_skip_rules else ('Service not installed' if not current_state_info.exists else '')),
+          'current_value': (current_state_info.state + ' / ' + current_state_info.start_mode if current_state_info.exists else 'Service not installed'),
+          'expected_value': service.description,
+          'status': ('PASS' if (not current_state_info.exists or (current_state_info.state == service.state and current_state_info.start_mode == service.start_mode)) else 'FAIL'),
+          'changed': false,
+          'skip_reason': ('User configured skip' if service.stig_id in windows_manage_stig_skip_rules else ('Service not installed' if not current_state_info.exists else '')),
           'check_mode': ansible_check_mode
-        }) | list) }}
+        })
+      ] }}
   vars:
-    all_services: "{{ (windows_manage_stig_system_services.critical_disable + windows_manage_stig_system_services.standard_disable + windows_manage_stig_system_services.essential_enable
-      + windows_manage_stig_system_services.conditional) }}"
-    current_state_info: "{{ (windows_manage_stig_services_current.results | selectattr('item.name', 'equalto', item.name) | first).services[item.name] | default({'exists':
-      false, 'state': 'unknown', 'start_mode': 'unknown'}) }}"
-    task_changed: false # Will be updated by actual task results
-    item: "{{ service }}"
-  loop: "{{ all_services }}"
+    current_state_info: "{{ (windows_manage_stig_services_current.results | selectattr('item.stig_id', 'equalto', service.stig_id) | list | first).services[service.name] | default({'exists': false, 'state': 'unknown', 'start_mode': 'unknown'}) }}"
+  loop: "{{ (windows_manage_stig_system_services.critical_disable + windows_manage_stig_system_services.standard_disable + windows_manage_stig_system_services.essential_enable + windows_manage_stig_system_services.conditional) }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or service.stig_id in windows_manage_stig_only_rules
   loop_control:
     loop_var: service
-    extended: true
   tags:
     - system_services
     - compliance

--- a/roles/windows_manage_stig/tasks/user_rights_assignment.yml
+++ b/roles/windows_manage_stig/tasks/user_rights_assignment.yml
@@ -310,6 +310,8 @@
     users: "{{ item.users }}"
   register: windows_manage_stig_user_rights_current
   loop: "{{ windows_manage_stig_user_rights }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or item.stig_id in windows_manage_stig_only_rules
   check_mode: true # Always run in check mode to get current state
   tags:
     - user_rights
@@ -339,23 +341,26 @@
 - name: STIG User Rights Assignment | AUDIT | Record compliance results
   ansible.builtin.set_fact:
     windows_manage_stig_results: >-
-      {{ windows_manage_stig_results | default([]) +
-        (windows_manage_stig_user_rights | map('combine', {
+      {{ windows_manage_stig_results | default([]) + [
+        user_right | combine({
           'rule_section': 'User Rights Assignment',
           'scored': true,
-          'current_value': ((windows_manage_stig_user_rights_current.results[ansible_loop.index0].users | default([]) | join(', ')) if (windows_manage_stig_user_rights_current.results[ansible_loop.index0].users | default([]) | length > 0) else 'No accounts assigned'),
-          'expected_value': item.expected,
-          'status': 'PASS' if (windows_manage_stig_user_rights_current.results[ansible_loop.index0].users | default([]) | sort == item.users | sort) else 'FAIL',
-          'changed': ((windows_manage_stig_user_rights_results.results | selectattr('item.stig_id', 'equalto', item.stig_id) | list | first).changed | default(false)),
-          'skip_reason': 'User configured skip' if item.stig_id in windows_manage_stig_skip_rules else '',
+          'current_value': (current_users | join(', ') if current_users | length > 0 else 'No accounts assigned'),
+          'expected_value': user_right.expected,
+          'status': ('PASS' if (current_users | sort == user_right.users | sort) else 'FAIL'),
+          'changed': changed_status,
+          'skip_reason': ('User configured skip' if user_right.stig_id in windows_manage_stig_skip_rules else ''),
           'check_mode': ansible_check_mode
-        }) | list) }}
+        })
+      ] }}
   vars:
-    item: "{{ user_right }}"
+    current_users: "{{ (windows_manage_stig_user_rights_current.results | selectattr('item.stig_id', 'equalto', user_right.stig_id) | list | first).users | default([]) }}"
+    changed_status: "{{ (windows_manage_stig_user_rights_results.results | selectattr('item.stig_id', 'equalto', user_right.stig_id) | list | first).changed | default(false) }}"
   loop: "{{ windows_manage_stig_user_rights }}"
+  when:
+    - windows_manage_stig_only_rules | length == 0 or user_right.stig_id in windows_manage_stig_only_rules
   loop_control:
     loop_var: user_right
-    extended: true
   tags:
     - user_rights
     - compliance


### PR DESCRIPTION
The only_rules parameters were not correctly filtering which controls execute. Three bugs were fixed:

1. CIS role: Add missing | list before | length after select()
2. STIG role: Add only_rules filter to AUDIT and Record tasks
3. STIG role: Fix Record tasks to append single item instead of entire matrix on each loop iteration

Backward compatible: Empty only_rules still runs all controls.

Fixes: #31 