### PR TITLE
windows_manage_stig_only_rules filtering ACA-4989

### DIFF
--- a/changelogs/fragments/ACA-4989-fix-stig-only-rules-filtering.yml
+++ b/changelogs/fragments/ACA-4989-fix-stig-only-rules-filtering.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - windows_manage_stig - Fixed ``windows_manage_stig_only_rules`` filtering to properly restrict rule execution to only specified STIG IDs.

--- a/roles/windows_manage_stig/tasks/audit_policies.yml
+++ b/roles/windows_manage_stig/tasks/audit_policies.yml
@@ -261,6 +261,7 @@
   register: windows_manage_stig_audit_results
   when:
     - item.stig_id not in windows_manage_stig_skip_rules
+    - windows_manage_stig_only_rules | length == 0 or item.stig_id in windows_manage_stig_only_rules
     - windows_manage_stig_audit_current_all.result.audit_policies[item.subcategory] | default('No Auditing') != item.expected
   tags:
     - audit_policies

--- a/roles/windows_manage_stig/tasks/main.yml
+++ b/roles/windows_manage_stig/tasks/main.yml
@@ -54,7 +54,6 @@
   ansible.builtin.include_tasks: account_policies.yml
   when:
     - "'account_policies' in windows_manage_stig_categories"
-    - windows_manage_stig_only_rules | length == 0 or (windows_manage_stig_only_rules | select('match', '^V-25424[0-6]$') | list | length > 0)
   tags:
     - stig_v254240_v254246
     - account_policies
@@ -64,7 +63,6 @@
   ansible.builtin.include_tasks: audit_policies.yml
   when:
     - "'audit_policies' in windows_manage_stig_categories"
-    - windows_manage_stig_only_rules | length == 0 or (windows_manage_stig_only_rules | select('match', '^V-25424[7-8].*|V-25425[0-8]$') | list | length > 0)
   tags:
     - stig_v254247_v254258
     - audit_policies
@@ -74,10 +72,6 @@
   ansible.builtin.include_tasks: user_rights_assignment.yml
   when:
     - "'user_rights' in windows_manage_stig_categories"
-    - >-
-      windows_manage_stig_only_rules | length == 0 or
-      (windows_manage_stig_only_rules | select('match', '^V-25445[1-9].*|V-254[4-5][0-9][0-9]$') |
-      list | length > 0)
   tags:
     - stig_v254451_v254500
     - user_rights
@@ -87,10 +81,6 @@
   ansible.builtin.include_tasks: security_options.yml
   when:
     - "'security_options' in windows_manage_stig_categories"
-    - >-
-      windows_manage_stig_only_rules | length == 0 or
-      (windows_manage_stig_only_rules | select('match', '^V-25425[9].*|V-254[2-3][0-9][0-9]$') |
-      list | length > 0)
   tags:
     - stig_v254259_v254350
     - security_options
@@ -100,10 +90,6 @@
   ansible.builtin.include_tasks: registry_settings.yml
   when:
     - "'registry_settings' in windows_manage_stig_categories"
-    - >-
-      windows_manage_stig_only_rules | length == 0 or
-      (windows_manage_stig_only_rules | select('match', '^V-25435[1-9].*|V-254[3-4][0-9][0-9]$') |
-      list | length > 0)
   tags:
     - stig_v254351_v254400
     - registry_settings
@@ -113,10 +99,6 @@
   ansible.builtin.include_tasks: system_services.yml
   when:
     - "'system_services' in windows_manage_stig_categories"
-    - >-
-      windows_manage_stig_only_rules | length == 0 or
-      (windows_manage_stig_only_rules | select('match', '^V-25440[1-9].*|V-254[4][0-9][0-9]$') |
-      list | length > 0)
   tags:
     - stig_v254401_v254450
     - system_services


### PR DESCRIPTION
Fixed regression where windows_manage_stig_only_rules variable failed to properly filter STIG rules.

Root causes:
1. Hardcoded regex patterns in main.yml excluded categories when rule IDs didn't match predefined ranges
2. Missing windows_manage_stig_only_rules filter in audit_policies.yml

Changes:
- Removed hardcoded regex patterns from all category includes in tasks/main.yml
- Added windows_manage_stig_only_rules filtering to tasks/audit_policies.yml
- Filtering now works consistently across all 6 STIG categories

The role now correctly processes only specified rules regardless of rule ID ranges or categories.