### PR TITLE
Fix STIG 6 severity controls from CAT II to CAT I

### DIFF
--- a/changelogs/fragments/issue-36-fix-stig-severity-mismatch.yml
+++ b/changelogs/fragments/issue-36-fix-stig-severity-mismatch.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - windows_manage_stig - Fixed 6 STIG controls that were incorrectly classified as CAT II instead of CAT I per official DISA documentation.

--- a/roles/windows_manage_stig/tasks/registry_settings.yml
+++ b/roles/windows_manage_stig/tasks/registry_settings.yml
@@ -38,7 +38,7 @@
         data: 1
         type: dword
         category: autoplay_media
-        severity: CAT II
+        severity: CAT I
         description: Disabled
       - stig_id: V-254354
         title: Configure Windows Error Reporting - Do not send additional data
@@ -231,7 +231,7 @@
         data: 0
         type: dword
         category: powershell_winrm
-        severity: CAT II
+        severity: CAT I
         description: Disabled
       - stig_id: V-254375
         title: Configure WinRM Service - Disallow unencrypted traffic
@@ -267,7 +267,7 @@
         data: 1
         type: dword
         category: powershell_winrm
-        severity: CAT II
+        severity: CAT I
         description: Enabled
       - stig_id: V-254379
         title: Configure Windows Firewall - Private profile state
@@ -296,7 +296,7 @@
         data: 1
         type: dword
         category: advanced_security
-        severity: CAT II
+        severity: CAT I
         description: Disabled
       - stig_id: V-254382
         title: Configure Camera and Microphone - Disable access

--- a/roles/windows_manage_stig/tasks/user_rights_assignment.yml
+++ b/roles/windows_manage_stig/tasks/user_rights_assignment.yml
@@ -131,7 +131,7 @@
         right: SeRemoteShutdownPrivilege
         users: [Administrators]
         expected: Administrators only
-        severity: CAT II
+        severity: CAT I
         description: Administrators only
       - stig_id: V-254468
         title: Generate security audits
@@ -188,7 +188,7 @@
         right: SeProfileSingleProcessPrivilege
         users: [Administrators]
         expected: Administrators only
-        severity: CAT II
+        severity: CAT I
         description: Administrators only
       - stig_id: V-254476
         title: Profile system performance


### PR DESCRIPTION
Per DISA STIG official documentation, the following controls are CAT I (high severity) but were incorrectly labeled as CAT II:

Registry Settings (roles/windows_manage_stig/tasks/registry_settings.yml):
- V-254353: AutoRun behavior configuration (Windows Error Reporting)
- V-254374: WinRM Digest authentication
- V-254378: Windows Firewall Domain profile state
- V-254381: Windows Search indexer backoff

User Rights Assignment (roles/windows_manage_stig/tasks/user_rights_assignment.yml):
- V-254467: Force shutdown from a remote system
- V-254475: Profile single process

All 6 controls verified against official STIG Viewer documentation: https://www.stigviewer.com/stigs/microsoft-windows-server-2022-security-technical-implementation-guide/

Fixes #36