### PR TITLE
Fix audit policy remediation to preserve paired success/failure controls

### DIFF
--- a/changelogs/fragments/issue-37-fix-audit-policy-paired-controls.yml
+++ b/changelogs/fragments/issue-37-fix-audit-policy-paired-controls.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - windows_manage_stig - Fixed audit policy remediation to preserve paired success/failure controls, preventing "whack-a-mole" effect where fixing one control inadvertently breaks its paired control.

--- a/roles/windows_manage_stig/tasks/audit_policies.yml
+++ b/roles/windows_manage_stig/tasks/audit_policies.yml
@@ -463,7 +463,7 @@
 - name: STIG Audit Policies | SCORED | Configure audit policies (modernized loop)
   ansible.windows.win_powershell:
     script: |
-      param($SubcategoryName, $SuccessEnabled, $FailureEnabled, $RuleId, $DcOnly)
+      param($SubcategoryName, $SuccessEnabled, $FailureEnabled, $RuleId, $DcOnly, $ExpectedValue)
 
       $ErrorActionPreference = 'Stop'
       try {
@@ -482,9 +482,44 @@
           }
         }
 
-        # Build auditpol command parameters
-        $successParam = if ($SuccessEnabled) { "enable" } else { "disable" }
-        $failureParam = if ($FailureEnabled) { "enable" } else { "disable" }
+        # Query current audit policy state to preserve paired controls
+        $currentAuditOutput = auditpol /get /subcategory:"$SubcategoryName" /r
+        $currentAudit = $currentAuditOutput | ConvertFrom-Csv
+        $currentSetting = $currentAudit.'Inclusion Setting'
+
+        # Determine current state
+        $currentSuccessEnabled = $currentSetting -match 'Success'
+        $currentFailureEnabled = $currentSetting -match 'Failure'
+
+        # Build auditpol command parameters - preserve existing settings for parameters not being changed
+        # Only modify the parameter that needs to change based on the expected value
+        switch ($ExpectedValue) {
+          'Success and Failure' {
+            # Both success and failure should be enabled
+            $successParam = if ($SuccessEnabled) { "enable" } else { "disable" }
+            $failureParam = if ($FailureEnabled) { "enable" } else { "disable" }
+          }
+          'Success' {
+            # Only success should be enabled, preserve current failure state
+            $successParam = if ($SuccessEnabled) { "enable" } else { "disable" }
+            $failureParam = if ($currentFailureEnabled) { "enable" } else { "disable" }
+          }
+          'Failure' {
+            # Only failure should be enabled, preserve current success state
+            $successParam = if ($currentSuccessEnabled) { "enable" } else { "disable" }
+            $failureParam = if ($FailureEnabled) { "enable" } else { "disable" }
+          }
+          'No Auditing' {
+            # Both should be disabled
+            $successParam = "disable"
+            $failureParam = "disable"
+          }
+          default {
+            # Fallback to original behavior if expected value is unexpected
+            $successParam = if ($SuccessEnabled) { "enable" } else { "disable" }
+            $failureParam = if ($FailureEnabled) { "enable" } else { "disable" }
+          }
+        }
 
         # Execute auditpol command
         $result = auditpol /set /subcategory:"$SubcategoryName" /success:$successParam /failure:$failureParam
@@ -496,6 +531,8 @@
             rule_id = $RuleId
             success_setting = $successParam
             failure_setting = $failureParam
+            previous_setting = $currentSetting
+            preserved_paired_control = ($ExpectedValue -in @('Success', 'Failure'))
             command_output = $result
             status = "success"
           }
@@ -521,6 +558,7 @@
       FailureEnabled: "{{ item.failure }}"
       RuleId: "{{ item.stig_id }}"
       DcOnly: "{{ item.dc_only }}"
+      ExpectedValue: "{{ item.expected }}"
   loop: "{{ windows_manage_stig_audit_policies }}"
   register: windows_manage_stig_audit_results
   when:


### PR DESCRIPTION
When remediating individual audit policy controls (e.g., V-254316 for failure auditing), the role was inadvertently disabling the paired control (e.g., V-254315 for success auditing) causing a "whack-a-mole" effect where fixing one control breaks another.

Changes:
- Query current audit policy state before remediation
- Preserve existing success/failure settings when remediating only one
- Only modify the specific parameter being remediated
- Add logic based on expected value:
  * "Success" - Set success as required, preserve current failure state
  * "Failure" - Set failure as required, preserve current success state
  * "Success and Failure" - Set both as required
  * "No Auditing" - Disable both

Affected control pairs:
- V-254315/V-254316 (Other Object Access Events)
- V-254317/V-254318 (Removable Storage)
- V-254319/V-254320 (Audit Policy Change)
- V-254323/V-254324 (Sensitive Privilege Use)
- V-254331/V-254332 (System Integrity)
- V-254360/V-254361 (File System)
- V-254362/V-254363 (Handle Manipulation)
- V-254384/V-254385 (Registry)
- V-254323/V-278948/V-278949 (Sensitive Privilege Use - 3 controls)

Fixes #37