### PR TITLE
feat(windows_manage_dns_client): add role for DNS client configuration

### DIFF
--- a/changelogs/fragments/add-windows-manage-dns-client.yml
+++ b/changelogs/fragments/add-windows-manage-dns-client.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_dns_client - new role for configuring Windows DNS client settings including DNS servers and suffix search lists per network adapter."

--- a/changelogs/fragments/add-windows-manage-dns-client.yml
+++ b/changelogs/fragments/add-windows-manage-dns-client.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - "windows_manage_dns_client - new role for configuring Windows DNS client settings including DNS servers and suffix search lists per network adapter."
+  - "windows_manage_dns_client - new role for configuring Windows DNS client settings including DNS servers and suffix search lists per network adapter
+    (https://github.com/redhat-cop/infra.windows_ops/pull/70)."

--- a/extensions/patterns/manage_dns_client/exec_env/README.md
+++ b/extensions/patterns/manage_dns_client/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/p3ck/apd-ee-25-experience:latest
+podman push quay.io/p3ck/apd-ee-25-experience:latest
+```

--- a/extensions/patterns/manage_dns_client/exec_env/README.md
+++ b/extensions/patterns/manage_dns_client/exec_env/README.md
@@ -3,6 +3,6 @@ Build EE manually, push to quay.io
 ```
 ansible-builder build
 # podman build -f context/Containerfile -t ansible-execution-env:latest context
-podman tag ansible-execution-env:latest quay.io/p3ck/apd-ee-25-experience:latest
-podman push quay.io/p3ck/apd-ee-25-experience:latest
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
 ```

--- a/extensions/patterns/manage_dns_client/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_dns_client/exec_env/execution-environment.yml
@@ -1,0 +1,13 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner
+  system:
+    - podman

--- a/extensions/patterns/manage_dns_client/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_dns_client/exec_env/execution-environment.yml
@@ -9,5 +9,3 @@ dependencies:
     package_pip: ansible-core
   ansible_runner:
     package_pip: ansible-runner
-  system:
-    - podman

--- a/extensions/patterns/manage_dns_client/exec_env/requirements.yml
+++ b/extensions/patterns/manage_dns_client/exec_env/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  # - name: ansible.experience_demo
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_dns_client/exec_env/requirements.yml
+++ b/extensions/patterns/manage_dns_client/exec_env/requirements.yml
@@ -1,6 +1,5 @@
 ---
 collections:
-  # - name: ansible.experience_demo
   - name: https://github.com/redhat-cop/infra.windows_ops.git
     type: git
     version: main

--- a/extensions/patterns/manage_dns_client/playbooks/run_manage_dns_client.yml
+++ b/extensions/patterns/manage_dns_client/playbooks/run_manage_dns_client.yml
@@ -1,0 +1,13 @@
+---
+- name: Manage Windows DNS Client
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Configure DNS client
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dns_client
+      vars:
+        windows_manage_dns_client_configurations:
+          - adapter_names: "{{ dns_client_adapter_names | default('*') }}"  # Set by survey
+            dns_servers: "{{ dns_client_dns_servers | split(',') }}"  # Set by survey
+...

--- a/extensions/patterns/manage_dns_client/playbooks/run_manage_dns_client.yml
+++ b/extensions/patterns/manage_dns_client/playbooks/run_manage_dns_client.yml
@@ -9,5 +9,5 @@
       vars:
         windows_manage_dns_client_configurations:
           - adapter_names: "{{ dns_client_adapter_names | default('*') }}"  # Set by survey
-            dns_servers: "{{ dns_client_dns_servers | split(',') }}"  # Set by survey
+            dns_servers: "{{ dns_client_dns_servers | split(',') | map('trim') | list }}"  # Set by survey
 ...

--- a/extensions/patterns/manage_dns_client/setup.yml
+++ b/extensions/patterns/manage_dns_client/setup.yml
@@ -14,7 +14,7 @@ controller_labels:
 controller_execution_environments:
   - name: apd-ee-25-windows
     description: Allow running Windows experience demo. Based on apd-ee-25.
-    image: quay.io/p3ck/apd-ee-25-experience:latest
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
     pull: always
 
 # Projects
@@ -27,10 +27,10 @@ controller_projects:
       seamless management of DNS client settings.
     organization: Default
     scm_branch: main
-    scm_clean: 'no'
-    scm_delete_on_update: 'no'
+    scm_clean: false
+    scm_delete_on_update: false
     scm_type: git
-    scm_update_on_launch: 'yes'
+    scm_update_on_launch: true
     scm_url: https://github.com/redhat-cop/infra.windows_ops.git
     credential: "{{ credential | default(omit, true) }}"
 

--- a/extensions/patterns/manage_dns_client/setup.yml
+++ b/extensions/patterns/manage_dns_client/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_dns_client_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_dns_client
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/p3ck/apd-ee-25-experience:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of DNS client configurations.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of DNS client settings.
+    organization: Default
+    scm_branch: main
+    scm_clean: 'no'
+    scm_delete_on_update: 'no'
+    scm_type: git
+    scm_update_on_launch: 'yes'
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage DNS Client
+    description: >
+      This job template manages DNS client configurations, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_dns_client_pattern
+      - run_manage_dns_client
+    playbook: "extensions/patterns/manage_dns_client/playbooks/run_manage_dns_client.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_dns_client.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_dns_client/template_surveys/manage_dns_client.yml
+++ b/extensions/patterns/manage_dns_client/template_surveys/manage_dns_client.yml
@@ -1,0 +1,16 @@
+---
+name: "Manage DNS Client Configuration Survey"
+description: "Survey to configure DNS client options"
+spec:
+  - question_name: "Adapter Names"
+    question_description: "Specify the network adapter name(s) to configure. Use '*' for all adapters."
+    required: true
+    variable: "dns_client_adapter_names"
+    type: "text"
+    default: "*"
+
+  - question_name: "DNS Servers"
+    question_description: "Comma-separated list of DNS server IP addresses (e.g., 10.0.0.1,10.0.0.2)"
+    required: true
+    variable: "dns_client_dns_servers"
+    type: "text"

--- a/roles/windows_manage_dns_client/README.md
+++ b/roles/windows_manage_dns_client/README.md
@@ -1,0 +1,44 @@
+# windows_manage_dns_client
+
+Configure Windows DNS client settings including DNS servers and suffix search lists per network adapter.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_dns_client_configurations` | list(dict) | `[]` | List of DNS client configurations to apply |
+
+Each configuration item supports:
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `adapter_names` | str/list | yes | Adapter name(s) to configure (`'*'` for all) |
+| `dns_servers` | list(str) | yes | Ordered list of DNS server IP addresses |
+| `suffix_search_list` | list(str) | no | DNS suffix search list for name resolution |
+
+## Example Playbook
+
+```yaml
+- name: Configure DNS client
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_dns_client
+      vars:
+        windows_manage_dns_client_configurations:
+          - adapter_names: '*'
+            dns_servers:
+              - 10.0.0.1
+              - 10.0.0.2
+            suffix_search_list:
+              - example.com
+              - corp.example.com
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_dns_client/README.md
+++ b/roles/windows_manage_dns_client/README.md
@@ -5,7 +5,7 @@ Configure Windows DNS client settings including DNS servers and suffix search li
 ## Requirements
 
 - Ansible >= 2.18
-- `ansible.windows` collection
+- `ansible.windows` collection (>= 3.1.0 required to set `suffix_search_list`)
 
 ## Role Variables
 
@@ -19,7 +19,7 @@ Each configuration item supports:
 |---|---|---|---|
 | `adapter_names` | str/list | yes | Adapter name(s) to configure (`'*'` for all) |
 | `dns_servers` | list(str) | yes | Ordered list of DNS server IP addresses |
-| `suffix_search_list` | list(str) | no | DNS suffix search list for name resolution |
+| `suffix_search_list` | list(str) | no | DNS suffix search list for name resolution (requires `ansible.windows` >= 3.1.0) |
 
 ## Example Playbook
 

--- a/roles/windows_manage_dns_client/defaults/main.yml
+++ b/roles/windows_manage_dns_client/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# List of DNS client configurations
+# Each item requires: adapter_names, dns_servers
+# Optional: suffix_search_list
+windows_manage_dns_client_configurations: []
+#  - adapter_names: '*'
+#    dns_servers:
+#      - 1.1.1.1
+#      - 8.8.8.8
+#    suffix_search_list:
+#      - contoso.com
+#      - example.com

--- a/roles/windows_manage_dns_client/handlers/main.yml
+++ b/roles/windows_manage_dns_client/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Flush DNS resolver cache
+  ansible.windows.win_command: ipconfig.exe /flushdns

--- a/roles/windows_manage_dns_client/meta/argument_specs.yml
+++ b/roles/windows_manage_dns_client/meta/argument_specs.yml
@@ -32,4 +32,5 @@ argument_specs:
             elements: str
             description:
               - DNS suffix search list for name resolution.
+              - Setting this option requires C(ansible.windows) >= 3.1.0.
             required: false

--- a/roles/windows_manage_dns_client/meta/argument_specs.yml
+++ b/roles/windows_manage_dns_client/meta/argument_specs.yml
@@ -1,0 +1,35 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Configure Windows DNS client settings.
+    description:
+      - Configure DNS servers and suffix search lists per network adapter.
+      - Automatically flushes the DNS resolver cache after changes.
+    options:
+      windows_manage_dns_client_configurations:
+        type: list
+        elements: dict
+        description:
+          - List of DNS client configurations to apply.
+          - Each item configures DNS servers for one or more network adapters.
+        default: []
+        options:
+          adapter_names:
+            type: raw
+            description:
+              - Adapter name or list of adapter names to configure.
+              - Use C('*') for all adapters.
+            required: true
+          dns_servers:
+            type: list
+            elements: str
+            description:
+              - Ordered list of DNS server IP addresses.
+            required: true
+          suffix_search_list:
+            type: list
+            elements: str
+            description:
+              - DNS suffix search list for name resolution.
+            required: false

--- a/roles/windows_manage_dns_client/meta/main.yml
+++ b/roles/windows_manage_dns_client/meta/main.yml
@@ -1,14 +1,17 @@
 ---
 galaxy_info:
+  role_name: windows_manage_dns_client
   author: Hen Yaish
-  description: Configure Windows DNS client settings
-  company: Red Hat
+  company: Red Hat, Inc.
+  description: Configure Windows DNS client settings including DNS servers and suffix search lists.
   license: GPL-3.0-or-later
   min_ansible_version: "2.18"
   platforms:
     - name: Windows
       versions:
-        - all
+        - "2019"
+        - "2022"
+        - "2025"
   galaxy_tags:
     - windows
     - dns

--- a/roles/windows_manage_dns_client/meta/main.yml
+++ b/roles/windows_manage_dns_client/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  author: Hen Yaish
+  description: Configure Windows DNS client settings
+  company: Red Hat
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - all
+  galaxy_tags:
+    - windows
+    - dns
+    - networking
+    - system
+
+dependencies: []

--- a/roles/windows_manage_dns_client/tasks/main.yml
+++ b/roles/windows_manage_dns_client/tasks/main.yml
@@ -1,0 +1,14 @@
+---
+- name: Configure DNS client
+  ansible.windows.win_dns_client:
+    adapter_names: "{{ item.adapter_names }}"
+    dns_servers: "{{ item.dns_servers }}"
+    suffix_search_list: "{{ item.suffix_search_list | default(omit, true) }}"
+  register: windows_manage_dns_client_result
+  loop: "{{ windows_manage_dns_client_configurations | select }}"
+  loop_control:
+    label: "{{ item.adapter_names }}"
+
+- name: Flush DNS resolver cache
+  ansible.windows.win_command: ipconfig.exe /flushdns
+  when: windows_manage_dns_client_result is changed

--- a/roles/windows_manage_dns_client/tasks/main.yml
+++ b/roles/windows_manage_dns_client/tasks/main.yml
@@ -3,8 +3,8 @@
   ansible.windows.win_dns_client:
     adapter_names: "{{ item.adapter_names }}"
     dns_servers: "{{ item.dns_servers }}"
-    suffix_search_list: "{{ item.suffix_search_list | default(omit, true) }}"
-  loop: "{{ windows_manage_dns_client_configurations | select }}"
+    suffix_search_list: "{{ item.suffix_search_list | default(omit) }}"
+  loop: "{{ windows_manage_dns_client_configurations }}"
   loop_control:
     label: "{{ item.adapter_names }}"
   notify: Flush DNS resolver cache

--- a/roles/windows_manage_dns_client/tasks/main.yml
+++ b/roles/windows_manage_dns_client/tasks/main.yml
@@ -4,11 +4,7 @@
     adapter_names: "{{ item.adapter_names }}"
     dns_servers: "{{ item.dns_servers }}"
     suffix_search_list: "{{ item.suffix_search_list | default(omit, true) }}"
-  register: windows_manage_dns_client_result
   loop: "{{ windows_manage_dns_client_configurations | select }}"
   loop_control:
     label: "{{ item.adapter_names }}"
-
-- name: Flush DNS resolver cache
-  ansible.windows.win_command: ipconfig.exe /flushdns
-  when: windows_manage_dns_client_result is changed
+  notify: Flush DNS resolver cache

--- a/tests/integration/targets/windows_ops_test_windows_manage_dns_client/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_dns_client/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_dns_client/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_dns_client/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+windows_manage_dns_client_test_adapter: Ethernet Instance 0
+windows_manage_dns_client_test_dns_a:
+  - 10.46.109.207
+  - 8.8.8.8
+windows_manage_dns_client_test_dns_b:
+  - 10.46.109.207
+  - 1.1.1.1

--- a/tests/integration/targets/windows_ops_test_windows_manage_dns_client/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_dns_client/tasks/main.yml
@@ -39,6 +39,18 @@
           - adapter_names: "{{ windows_manage_dns_client_test_adapter }}"
             dns_servers: "{{ windows_manage_dns_client_test_dns_a }}"
 
+    - name: Verify DNS servers after idempotency run
+      ansible.windows.win_shell: |
+        (Get-DnsClientServerAddress -InterfaceAlias '{{ windows_manage_dns_client_test_adapter }}' -AddressFamily IPv4).ServerAddresses
+      register: windows_manage_dns_client_verify_idempotent
+      changed_when: false
+
+    - name: Assert DNS servers unchanged after idempotency run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_dns_client_verify_idempotent.stdout_lines == windows_manage_dns_client_test_dns_a
+        fail_msg: "DNS servers changed after a repeat run; role is not idempotent"
+
     - name: Configure DNS servers (state B)
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_dns_client

--- a/tests/integration/targets/windows_ops_test_windows_manage_dns_client/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_dns_client/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+- name: Test DNS client configuration
+  block:
+    - name: Capture current DNS servers
+      ansible.windows.win_shell: |
+        (Get-DnsClientServerAddress -InterfaceAlias '{{ windows_manage_dns_client_test_adapter }}' -AddressFamily IPv4).ServerAddresses
+      register: windows_manage_dns_client_original_raw
+      changed_when: false
+
+    - name: Record original DNS servers
+      ansible.builtin.set_fact:
+        windows_manage_dns_client_original_servers: "{{ windows_manage_dns_client_original_raw.stdout_lines }}"
+
+    - name: Configure DNS servers (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dns_client
+      vars:
+        windows_manage_dns_client_configurations:
+          - adapter_names: "{{ windows_manage_dns_client_test_adapter }}"
+            dns_servers: "{{ windows_manage_dns_client_test_dns_a }}"
+
+    - name: Verify DNS servers after state A
+      ansible.windows.win_shell: |
+        (Get-DnsClientServerAddress -InterfaceAlias '{{ windows_manage_dns_client_test_adapter }}' -AddressFamily IPv4).ServerAddresses
+      register: windows_manage_dns_client_verify_a
+      changed_when: false
+
+    - name: Assert DNS servers match state A
+      ansible.builtin.assert:
+        that:
+          - windows_manage_dns_client_verify_a.stdout_lines == windows_manage_dns_client_test_dns_a
+        fail_msg: "DNS servers were not set to state A"
+
+    - name: Run role again to verify idempotency (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dns_client
+      vars:
+        windows_manage_dns_client_configurations:
+          - adapter_names: "{{ windows_manage_dns_client_test_adapter }}"
+            dns_servers: "{{ windows_manage_dns_client_test_dns_a }}"
+
+    - name: Configure DNS servers (state B)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dns_client
+      vars:
+        windows_manage_dns_client_configurations:
+          - adapter_names: "{{ windows_manage_dns_client_test_adapter }}"
+            dns_servers: "{{ windows_manage_dns_client_test_dns_b }}"
+
+    - name: Verify DNS servers after state B
+      ansible.windows.win_shell: |
+        (Get-DnsClientServerAddress -InterfaceAlias '{{ windows_manage_dns_client_test_adapter }}' -AddressFamily IPv4).ServerAddresses
+      register: windows_manage_dns_client_verify_b
+      changed_when: false
+
+    - name: Assert DNS servers match state B
+      ansible.builtin.assert:
+        that:
+          - windows_manage_dns_client_verify_b.stdout_lines == windows_manage_dns_client_test_dns_b
+        fail_msg: "DNS servers were not set to state B"
+
+  always:
+    - name: Restore original DNS configuration
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dns_client
+      vars:
+        windows_manage_dns_client_configurations:
+          - adapter_names: "{{ windows_manage_dns_client_test_adapter }}"
+            dns_servers: "{{ windows_manage_dns_client_original_servers }}"


### PR DESCRIPTION
##### SUMMARY
Add new `windows_manage_dns_client` role for configuring Windows DNS client settings.

- Configures DNS servers and suffix search lists per network adapter using `ansible.windows.win_dns_client`
- Automatically flushes DNS resolver cache after changes
- Supports multiple adapter configurations via a list variable
- Includes integration tests with two-state verification and restore
- Includes AAP pattern (setup, playbook, survey, execution environment)
- Includes changelog fragment

Part of ACA-2792 Batch 2 (Network and Remote Access).

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
roles/windows_manage_dns_client