### PR TITLE
feat(windows_manage_network): add role for network configuration

### DIFF
--- a/changelogs/fragments/add-windows-manage-network.yml
+++ b/changelogs/fragments/add-windows-manage-network.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - "windows_manage_network - new role for configuring Windows network settings including IPv6, NetBIOS, LMHOSTS lookup, and static routes."
+  - "windows_manage_network - new role for configuring Windows network settings including IPv6, NetBIOS, LMHOSTS lookup, and static routes
+    (https://github.com/redhat-cop/infra.windows_ops/pull/71)."

--- a/changelogs/fragments/add-windows-manage-network.yml
+++ b/changelogs/fragments/add-windows-manage-network.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_network - new role for configuring Windows network settings including IPv6, NetBIOS, LMHOSTS lookup, and static routes."

--- a/extensions/patterns/manage_network/exec_env/README.md
+++ b/extensions/patterns/manage_network/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/p3ck/apd-ee-25-experience:latest
+podman push quay.io/p3ck/apd-ee-25-experience:latest
+```

--- a/extensions/patterns/manage_network/exec_env/README.md
+++ b/extensions/patterns/manage_network/exec_env/README.md
@@ -2,7 +2,6 @@ Build EE manually, push to quay.io
 
 ```
 ansible-builder build
-# podman build -f context/Containerfile -t ansible-execution-env:latest context
-podman tag ansible-execution-env:latest quay.io/p3ck/apd-ee-25-experience:latest
-podman push quay.io/p3ck/apd-ee-25-experience:latest
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
 ```

--- a/extensions/patterns/manage_network/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_network/exec_env/execution-environment.yml
@@ -1,0 +1,13 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner
+  system:
+    - podman

--- a/extensions/patterns/manage_network/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_network/exec_env/execution-environment.yml
@@ -9,5 +9,3 @@ dependencies:
     package_pip: ansible-core
   ansible_runner:
     package_pip: ansible-runner
-  system:
-    - podman

--- a/extensions/patterns/manage_network/exec_env/requirements.yml
+++ b/extensions/patterns/manage_network/exec_env/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  # - name: ansible.experience_demo
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_network/exec_env/requirements.yml
+++ b/extensions/patterns/manage_network/exec_env/requirements.yml
@@ -1,6 +1,5 @@
 ---
 collections:
-  # - name: ansible.experience_demo
   - name: https://github.com/redhat-cop/infra.windows_ops.git
     type: git
     version: main

--- a/extensions/patterns/manage_network/playbooks/run_manage_network.yml
+++ b/extensions/patterns/manage_network/playbooks/run_manage_network.yml
@@ -1,0 +1,14 @@
+---
+- name: Manage Windows Network Configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Configure network settings
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_network
+      vars:
+        windows_manage_network_ipv6_enable: "{{ network_ipv6_enable | default(true) | bool }}"  # Set by survey
+        windows_manage_network_lmhosts_enable: "{{ network_lmhosts_enable | default(true) | bool }}"  # Set by survey
+        windows_manage_network_netbios_enable: "{{ network_netbios_enable | default(true) | bool }}"  # Set by survey
+        windows_manage_network_reboot: "{{ network_reboot | default(true) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_network/setup.yml
+++ b/extensions/patterns/manage_network/setup.yml
@@ -14,7 +14,7 @@ controller_labels:
 controller_execution_environments:
   - name: apd-ee-25-windows
     description: Allow running Windows experience demo. Based on apd-ee-25.
-    image: quay.io/p3ck/apd-ee-25-experience:latest
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
     pull: always
 
 # Projects
@@ -27,10 +27,10 @@ controller_projects:
       seamless management of network settings.
     organization: Default
     scm_branch: main
-    scm_clean: 'no'
-    scm_delete_on_update: 'no'
+    scm_clean: false
+    scm_delete_on_update: false
     scm_type: git
-    scm_update_on_launch: 'yes'
+    scm_update_on_launch: true
     scm_url: https://github.com/redhat-cop/infra.windows_ops.git
     credential: "{{ credential | default(omit, true) }}"
 

--- a/extensions/patterns/manage_network/setup.yml
+++ b/extensions/patterns/manage_network/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_network_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_network
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/p3ck/apd-ee-25-experience:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of network configurations.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of network settings.
+    organization: Default
+    scm_branch: main
+    scm_clean: 'no'
+    scm_delete_on_update: 'no'
+    scm_type: git
+    scm_update_on_launch: 'yes'
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Network
+    description: >
+      This job template manages network configurations, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_network_pattern
+      - run_manage_network
+    playbook: "extensions/patterns/manage_network/playbooks/run_manage_network.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_network.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_network/template_surveys/manage_network.yml
+++ b/extensions/patterns/manage_network/template_surveys/manage_network.yml
@@ -1,0 +1,43 @@
+---
+name: "Manage Network Configuration Survey"
+description: "Survey to configure network options"
+spec:
+  - question_name: "Enable IPv6"
+    question_description: "Enable or disable IPv6 on all network interfaces"
+    required: true
+    variable: "network_ipv6_enable"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Enable LMHOSTS Lookup"
+    question_description: "Enable or disable LMHOSTS lookup"
+    required: true
+    variable: "network_lmhosts_enable"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Enable NetBIOS"
+    question_description: "Enable or disable NetBIOS on all network interfaces"
+    required: true
+    variable: "network_netbios_enable"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Reboot After Changes"
+    question_description: "Reboot the system after network changes (false = DNS flush only)"
+    required: true
+    variable: "network_reboot"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"

--- a/roles/windows_manage_network/README.md
+++ b/roles/windows_manage_network/README.md
@@ -1,0 +1,51 @@
+# windows_manage_network
+
+Configure Windows network settings including IPv6, NetBIOS, LMHOSTS lookup, and static routes.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+- `community.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_network_ipv6_enable` | bool | `true` | Enable or disable IPv6 on all interfaces |
+| `windows_manage_network_lmhosts_enable` | bool | `true` | Enable or disable LMHOSTS lookup |
+| `windows_manage_network_netbios_enable` | bool | `true` | Enable or disable NetBIOS on all interfaces |
+| `windows_manage_network_reboot` | bool | `true` | Reboot after changes (false = DNS flush only) |
+| `windows_manage_network_routes` | list(dict) | `[]` | Static route configurations |
+
+Each route item supports:
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `destination` | str | yes | Network destination in CIDR format |
+| `gateway` | str | when present | Gateway IP address |
+| `metric` | int | no | Route metric value |
+| `state` | str | yes | `present` or `absent` |
+
+## Example Playbook
+
+```yaml
+- name: Configure network settings
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_network
+      vars:
+        windows_manage_network_ipv6_enable: false
+        windows_manage_network_netbios_enable: false
+        windows_manage_network_lmhosts_enable: false
+        windows_manage_network_reboot: false
+        windows_manage_network_routes:
+          - destination: 192.168.100.0/24
+            gateway: 10.0.0.1
+            metric: 1
+            state: present
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_network/README.md
+++ b/roles/windows_manage_network/README.md
@@ -15,16 +15,21 @@ Configure Windows network settings including IPv6, NetBIOS, LMHOSTS lookup, and 
 | `windows_manage_network_ipv6_enable` | bool | `true` | Enable or disable IPv6 on all interfaces |
 | `windows_manage_network_lmhosts_enable` | bool | `true` | Enable or disable LMHOSTS lookup |
 | `windows_manage_network_netbios_enable` | bool | `true` | Enable or disable NetBIOS on all interfaces |
-| `windows_manage_network_reboot` | bool | `true` | Reboot after changes (false = DNS flush only) |
+| `windows_manage_network_reboot` | bool | `true` | Reboot when a change requires it (false = DNS flush only) |
 | `windows_manage_network_routes` | list(dict) | `[]` | Static route configurations |
+
+> **Note:** IPv6, LMHOSTS, and NetBIOS are enforced to their configured values
+> on every run (full-state), so running the role only to manage routes still
+> applies those settings. Static routes are additive — only the routes listed
+> in `windows_manage_network_routes` are managed; any others are left untouched.
 
 Each route item supports:
 
 | Key | Type | Required | Description |
 |---|---|---|---|
 | `destination` | str | yes | Network destination in CIDR format |
-| `gateway` | str | when present | Gateway IP address |
-| `metric` | int | no | Route metric value |
+| `gateway` | str | no | Gateway IP address (defaults to `0.0.0.0`) |
+| `metric` | int | no | Route metric value (defaults to `1`) |
 | `state` | str | yes | `present` or `absent` |
 
 ## Example Playbook

--- a/roles/windows_manage_network/defaults/main.yml
+++ b/roles/windows_manage_network/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+# IPv6, LMHOSTS, and NetBIOS are enforced to these values on every run.
+
 # Enable or disable IPv6
 windows_manage_network_ipv6_enable: true
 
@@ -8,10 +10,11 @@ windows_manage_network_lmhosts_enable: true
 # Enable or disable NetBIOS
 windows_manage_network_netbios_enable: true
 
-# Reboot after IPv6/NetBIOS changes
+# Reboot when a change requires it (IPv6/LMHOSTS changed or NetBIOS
+# reports reboot_required). When false, the DNS cache is flushed instead.
 windows_manage_network_reboot: true
 
-# Static route configuration
+# Static route configuration (additive: only the listed routes are managed).
 # Each item requires: destination, state
-# When state is present also required: gateway, metric
+# gateway (defaults to 0.0.0.0) and metric (defaults to 1) are optional.
 windows_manage_network_routes: []

--- a/roles/windows_manage_network/defaults/main.yml
+++ b/roles/windows_manage_network/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# Enable or disable IPv6
+windows_manage_network_ipv6_enable: true
+
+# Enable or disable LMHOSTS lookup
+windows_manage_network_lmhosts_enable: true
+
+# Enable or disable NetBIOS
+windows_manage_network_netbios_enable: true
+
+# Reboot after IPv6/NetBIOS changes
+windows_manage_network_reboot: true
+
+# Static route configuration
+# Each item requires: destination, state
+# When state is present also required: gateway, metric
+windows_manage_network_routes: []

--- a/roles/windows_manage_network/meta/argument_specs.yml
+++ b/roles/windows_manage_network/meta/argument_specs.yml
@@ -1,0 +1,61 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Configure Windows network settings.
+    description:
+      - Configure IPv6, NetBIOS, LMHOSTS lookup, and static routes on Windows hosts.
+      - Optionally reboots or flushes DNS cache after network changes.
+    options:
+      windows_manage_network_ipv6_enable:
+        type: bool
+        description:
+          - Enable or disable IPv6 on all network interfaces.
+        default: true
+      windows_manage_network_lmhosts_enable:
+        type: bool
+        description:
+          - Enable or disable LMHOSTS lookup.
+        default: true
+      windows_manage_network_netbios_enable:
+        type: bool
+        description:
+          - Enable or disable NetBIOS on all network interfaces.
+        default: true
+      windows_manage_network_reboot:
+        type: bool
+        description:
+          - Reboot the system after IPv6 or NetBIOS changes.
+          - When false, only flushes the DNS resolver cache.
+        default: true
+      windows_manage_network_routes:
+        type: list
+        elements: dict
+        description:
+          - List of static route configurations.
+        default: []
+        options:
+          destination:
+            type: str
+            description:
+              - Network destination in CIDR format (e.g., C(192.168.1.0/24)).
+            required: true
+          gateway:
+            type: str
+            description:
+              - Gateway IP address for the route.
+              - Required when I(state=present).
+            required: false
+          metric:
+            type: int
+            description:
+              - Route metric value.
+            required: false
+          state:
+            type: str
+            description:
+              - Whether the route should be present or absent.
+            required: true
+            choices:
+              - present
+              - absent

--- a/roles/windows_manage_network/meta/argument_specs.yml
+++ b/roles/windows_manage_network/meta/argument_specs.yml
@@ -6,27 +6,39 @@ argument_specs:
     description:
       - Configure IPv6, NetBIOS, LMHOSTS lookup, and static routes on Windows hosts.
       - Optionally reboots or flushes DNS cache after network changes.
+      - >-
+        IPv6, LMHOSTS, and NetBIOS are enforced to their configured value on
+        every run (full-state), so running the role only to manage routes will
+        still apply the IPv6, LMHOSTS, and NetBIOS defaults. Static routes are
+        additive; only the routes listed in I(windows_manage_network_routes)
+        are managed and any others are left untouched.
     options:
       windows_manage_network_ipv6_enable:
         type: bool
         description:
           - Enable or disable IPv6 on all network interfaces.
+          - Enforced on every run regardless of the previous state.
         default: true
       windows_manage_network_lmhosts_enable:
         type: bool
         description:
           - Enable or disable LMHOSTS lookup.
+          - Enforced on every run regardless of the previous state.
         default: true
       windows_manage_network_netbios_enable:
         type: bool
         description:
           - Enable or disable NetBIOS on all network interfaces.
+          - Enforced on every run regardless of the previous state.
         default: true
       windows_manage_network_reboot:
         type: bool
         description:
-          - Reboot the system after IPv6 or NetBIOS changes.
-          - When false, only flushes the DNS resolver cache.
+          - Reboot the system when a network change requires it.
+          - >-
+            A reboot is triggered when IPv6 or LMHOSTS changed, or when
+            C(win_netbios) reports C(reboot_required).
+          - When false, the DNS resolver cache is flushed instead.
         default: true
       windows_manage_network_routes:
         type: list
@@ -44,12 +56,13 @@ argument_specs:
             type: str
             description:
               - Gateway IP address for the route.
-              - Required when I(state=present).
+              - When omitted, C(win_route) defaults the gateway to C(0.0.0.0).
             required: false
           metric:
             type: int
             description:
               - Route metric value.
+              - When omitted, C(win_route) defaults the metric to C(1).
             required: false
           state:
             type: str

--- a/roles/windows_manage_network/meta/main.yml
+++ b/roles/windows_manage_network/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_network
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Configure Windows network settings including IPv6, NetBIOS, LMHOSTS, and static routes.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - network
+    - configuration
+dependencies: []

--- a/roles/windows_manage_network/tasks/main.yml
+++ b/roles/windows_manage_network/tasks/main.yml
@@ -26,18 +26,26 @@
     gateway: "{{ item.gateway | default(omit) }}"
     metric: "{{ item.metric | default(omit) }}"
     state: "{{ item.state }}"
-  loop: "{{ windows_manage_network_routes | select }}"
+  loop: "{{ windows_manage_network_routes }}"
   loop_control:
     label: "{{ item.destination }}"
+
+# NetBIOS changes usually take effect immediately, so rely on the module's
+# reboot_required signal instead of a blanket "changed". IPv6 (adapter binding)
+# and LMHOSTS (registry) do not report a signal, so a change there is assumed
+# to require a reboot.
+- name: Determine whether network changes require a reboot
+  ansible.builtin.set_fact:
+    windows_manage_network_reboot_required: "{{ windows_manage_network_ipv6 is changed
+      or windows_manage_network_lmhosts is changed
+      or (windows_manage_network_netbios.reboot_required | default(false) | bool) }}"
 
 - name: Flush DNS resolver cache
   ansible.windows.win_command: ipconfig.exe /flushdns
   changed_when: false
   when:
     - not windows_manage_network_reboot | bool
-    - windows_manage_network_ipv6 is changed or
-      windows_manage_network_lmhosts is changed or
-      windows_manage_network_netbios is changed
+    - windows_manage_network_reboot_required | bool
 
 - name: Reboot system
   ansible.windows.win_reboot:
@@ -45,6 +53,4 @@
     msg: "Ansible reboot after network configuration"
   when:
     - windows_manage_network_reboot | bool
-    - windows_manage_network_ipv6 is changed or
-      windows_manage_network_lmhosts is changed or
-      windows_manage_network_netbios is changed
+    - windows_manage_network_reboot_required | bool

--- a/roles/windows_manage_network/tasks/main.yml
+++ b/roles/windows_manage_network/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- name: Configure IPv6 on all interfaces
+  community.windows.win_net_adapter_feature:
+    interface: '*'
+    component_id:
+      - ms_tcpip6
+    state: "{{ 'enabled' if windows_manage_network_ipv6_enable | bool else 'disabled' }}"
+  register: windows_manage_network_ipv6
+
+- name: Configure LMHOSTS lookup setting
+  ansible.windows.win_regedit:
+    path: HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters
+    name: EnableLMHOSTS
+    type: dword
+    data: "{{ 1 if windows_manage_network_lmhosts_enable | bool else 0 }}"
+
+- name: Configure NetBIOS on all interfaces
+  community.windows.win_netbios:
+    state: "{{ 'enabled' if windows_manage_network_netbios_enable | bool else 'disabled' }}"
+  register: windows_manage_network_netbios
+
+- name: Configure static network routes
+  ansible.windows.win_route:
+    destination: "{{ item.destination }}"
+    gateway: "{{ item.gateway | default(omit) }}"
+    metric: "{{ item.metric | default(omit) }}"
+    state: "{{ item.state }}"
+  loop: "{{ windows_manage_network_routes | select }}"
+  loop_control:
+    label: "{{ item.destination }}"
+
+- name: Flush DNS resolver cache
+  ansible.windows.win_command: ipconfig.exe /flushdns
+  when:
+    - not windows_manage_network_reboot | bool
+    - windows_manage_network_ipv6 is changed or
+      windows_manage_network_netbios is changed
+
+- name: Reboot system
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: "Ansible reboot after network configuration"
+  when:
+    - windows_manage_network_reboot | bool
+    - windows_manage_network_ipv6 is changed or
+      windows_manage_network_netbios is changed

--- a/roles/windows_manage_network/tasks/main.yml
+++ b/roles/windows_manage_network/tasks/main.yml
@@ -31,6 +31,7 @@
 
 - name: Flush DNS resolver cache
   ansible.windows.win_command: ipconfig.exe /flushdns
+  changed_when: false
   when:
     - not windows_manage_network_reboot | bool
     - windows_manage_network_ipv6 is changed or

--- a/roles/windows_manage_network/tasks/main.yml
+++ b/roles/windows_manage_network/tasks/main.yml
@@ -13,6 +13,7 @@
     name: EnableLMHOSTS
     type: dword
     data: "{{ 1 if windows_manage_network_lmhosts_enable | bool else 0 }}"
+  register: windows_manage_network_lmhosts
 
 - name: Configure NetBIOS on all interfaces
   community.windows.win_netbios:
@@ -35,6 +36,7 @@
   when:
     - not windows_manage_network_reboot | bool
     - windows_manage_network_ipv6 is changed or
+      windows_manage_network_lmhosts is changed or
       windows_manage_network_netbios is changed
 
 - name: Reboot system
@@ -44,4 +46,5 @@
   when:
     - windows_manage_network_reboot | bool
     - windows_manage_network_ipv6 is changed or
+      windows_manage_network_lmhosts is changed or
       windows_manage_network_netbios is changed

--- a/tests/integration/targets/windows_ops_test_windows_manage_network/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_network/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_network/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_network/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+windows_manage_network_test_route_a:
+  destination: 198.51.100.0/24
+  gateway: 10.46.109.254
+  metric: 10
+  state: present
+windows_manage_network_test_route_b:
+  destination: 203.0.113.0/24
+  gateway: 10.46.109.254
+  metric: 10
+  state: present

--- a/tests/integration/targets/windows_ops_test_windows_manage_network/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_network/tasks/main.yml
@@ -57,7 +57,33 @@
         windows_manage_network_routes:
           - "{{ windows_manage_network_test_route_a }}"
 
-    - name: Apply network configuration (state B - LMHOSTS enabled, route B)
+    - name: Verify LMHOSTS still disabled after idempotency run
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters
+        name: EnableLMHOSTS
+      register: windows_manage_network_verify_lmhosts_idempotent
+
+    - name: Assert LMHOSTS unchanged after idempotency run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_network_verify_lmhosts_idempotent.value == 0
+        fail_msg: "LMHOSTS changed after a repeat run; role is not idempotent"
+
+    - name: Verify route A still present after idempotency run
+      ansible.windows.win_shell: |
+        Get-NetRoute -DestinationPrefix '{{ windows_manage_network_test_route_a.destination }}' -ErrorAction SilentlyContinue | Measure-Object | Select-Object -ExpandProperty Count
+      register: windows_manage_network_verify_route_a_idempotent
+      changed_when: false
+
+    - name: Assert route A unchanged after idempotency run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_network_verify_route_a_idempotent.stdout | trim | int > 0
+        fail_msg: "Route A missing after a repeat run; role is not idempotent"
+
+    # State B flips LMHOSTS on, adds route B, and removes route A to exercise
+    # state: absent and confirm routes are managed additively (only listed ones).
+    - name: Apply network configuration (state B - LMHOSTS enabled, route B, route A removed)
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_network
       vars:
@@ -67,6 +93,8 @@
         windows_manage_network_reboot: false
         windows_manage_network_routes:
           - "{{ windows_manage_network_test_route_b }}"
+          - destination: "{{ windows_manage_network_test_route_a.destination }}"
+            state: absent
 
     - name: Verify LMHOSTS enabled after state B
       ansible.windows.win_reg_stat:
@@ -91,6 +119,18 @@
         that:
           - windows_manage_network_verify_route_b.stdout | trim | int > 0
         fail_msg: "Route B was not created"
+
+    - name: Verify route A removed after state B
+      ansible.windows.win_shell: |
+        Get-NetRoute -DestinationPrefix '{{ windows_manage_network_test_route_a.destination }}' -ErrorAction SilentlyContinue | Measure-Object | Select-Object -ExpandProperty Count
+      register: windows_manage_network_verify_route_a_absent
+      changed_when: false
+
+    - name: Assert route A was removed
+      ansible.builtin.assert:
+        that:
+          - windows_manage_network_verify_route_a_absent.stdout | trim | int == 0
+        fail_msg: "Route A was not removed by state: absent"
 
   always:
     - name: Restore original LMHOSTS setting

--- a/tests/integration/targets/windows_ops_test_windows_manage_network/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_network/tasks/main.yml
@@ -1,0 +1,111 @@
+---
+- name: Test network configuration
+  block:
+    - name: Capture original LMHOSTS setting
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters
+        name: EnableLMHOSTS
+      register: windows_manage_network_original_lmhosts
+
+    - name: Record original LMHOSTS value
+      ansible.builtin.set_fact:
+        windows_manage_network_original_lmhosts_data: "{{ windows_manage_network_original_lmhosts.value | default(1) }}"
+
+    - name: Apply network configuration (state A - LMHOSTS disabled, route A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_network
+      vars:
+        windows_manage_network_ipv6_enable: true
+        windows_manage_network_lmhosts_enable: false
+        windows_manage_network_netbios_enable: true
+        windows_manage_network_reboot: false
+        windows_manage_network_routes:
+          - "{{ windows_manage_network_test_route_a }}"
+
+    - name: Verify LMHOSTS disabled after state A
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters
+        name: EnableLMHOSTS
+      register: windows_manage_network_verify_lmhosts_a
+
+    - name: Assert LMHOSTS is disabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_network_verify_lmhosts_a.value == 0
+        fail_msg: "LMHOSTS was not disabled"
+
+    - name: Verify route A exists
+      ansible.windows.win_shell: |
+        Get-NetRoute -DestinationPrefix '{{ windows_manage_network_test_route_a.destination }}' -ErrorAction SilentlyContinue | Measure-Object | Select-Object -ExpandProperty Count
+      register: windows_manage_network_verify_route_a
+      changed_when: false
+
+    - name: Assert route A was created
+      ansible.builtin.assert:
+        that:
+          - windows_manage_network_verify_route_a.stdout | trim | int > 0
+        fail_msg: "Route A was not created"
+
+    - name: Run role again to verify idempotency (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_network
+      vars:
+        windows_manage_network_ipv6_enable: true
+        windows_manage_network_lmhosts_enable: false
+        windows_manage_network_netbios_enable: true
+        windows_manage_network_reboot: false
+        windows_manage_network_routes:
+          - "{{ windows_manage_network_test_route_a }}"
+
+    - name: Apply network configuration (state B - LMHOSTS enabled, route B)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_network
+      vars:
+        windows_manage_network_ipv6_enable: true
+        windows_manage_network_lmhosts_enable: true
+        windows_manage_network_netbios_enable: true
+        windows_manage_network_reboot: false
+        windows_manage_network_routes:
+          - "{{ windows_manage_network_test_route_b }}"
+
+    - name: Verify LMHOSTS enabled after state B
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters
+        name: EnableLMHOSTS
+      register: windows_manage_network_verify_lmhosts_b
+
+    - name: Assert LMHOSTS is enabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_network_verify_lmhosts_b.value == 1
+        fail_msg: "LMHOSTS was not enabled"
+
+    - name: Verify route B exists
+      ansible.windows.win_shell: |
+        Get-NetRoute -DestinationPrefix '{{ windows_manage_network_test_route_b.destination }}' -ErrorAction SilentlyContinue | Measure-Object | Select-Object -ExpandProperty Count
+      register: windows_manage_network_verify_route_b
+      changed_when: false
+
+    - name: Assert route B was created
+      ansible.builtin.assert:
+        that:
+          - windows_manage_network_verify_route_b.stdout | trim | int > 0
+        fail_msg: "Route B was not created"
+
+  always:
+    - name: Restore original LMHOSTS setting
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters
+        name: EnableLMHOSTS
+        type: dword
+        data: "{{ windows_manage_network_original_lmhosts_data }}"
+
+    - name: Remove test route A
+      ansible.windows.win_route:
+        destination: "{{ windows_manage_network_test_route_a.destination }}"
+        state: absent
+
+    - name: Remove test route B
+      ansible.windows.win_route:
+        destination: "{{ windows_manage_network_test_route_b.destination }}"
+        state: absent


### PR DESCRIPTION
##### SUMMARY
Add new `windows_manage_network` role for configuring Windows network settings.

- Configure IPv6 enable/disable on all interfaces using `community.windows.win_net_adapter_feature`
- Configure LMHOSTS lookup setting via registry
- Configure NetBIOS enable/disable using `community.windows.win_netbios`
- Manage static network routes using `ansible.windows.win_route`
- Optional DNS cache flush or system reboot after changes
- Includes integration tests with two-state verification (LMHOSTS toggle, route creation) and restore
- Includes AAP pattern (setup, playbook, survey, execution environment)
- Includes changelog fragment

Part of ACA-2792 Batch 2 (Network and Remote Access).

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
roles/windows_manage_network