### PR TITLE
feat(windows_manage_hosts_file): add role for hosts file management

### DIFF
--- a/changelogs/fragments/add-windows-manage-hosts-file.yml
+++ b/changelogs/fragments/add-windows-manage-hosts-file.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_hosts_file - new role for managing Windows hosts file entries with optional self-entry and IPv4/IPv6 filtering."

--- a/changelogs/fragments/add-windows-manage-hosts-file.yml
+++ b/changelogs/fragments/add-windows-manage-hosts-file.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - "windows_manage_hosts_file - new role for managing Windows hosts file entries with optional self-entry and IPv4/IPv6 filtering."
+  - "windows_manage_hosts_file - new role for managing Windows hosts file entries with optional self-entry and IPv4/IPv6 filtering
+    (https://github.com/redhat-cop/infra.windows_ops/pull/72)."

--- a/extensions/patterns/manage_hosts_file/exec_env/README.md
+++ b/extensions/patterns/manage_hosts_file/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/p3ck/apd-ee-25-experience:latest
+podman push quay.io/p3ck/apd-ee-25-experience:latest
+```

--- a/extensions/patterns/manage_hosts_file/exec_env/README.md
+++ b/extensions/patterns/manage_hosts_file/exec_env/README.md
@@ -3,6 +3,6 @@ Build EE manually, push to quay.io
 ```
 ansible-builder build
 # podman build -f context/Containerfile -t ansible-execution-env:latest context
-podman tag ansible-execution-env:latest quay.io/p3ck/apd-ee-25-experience:latest
-podman push quay.io/p3ck/apd-ee-25-experience:latest
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
 ```

--- a/extensions/patterns/manage_hosts_file/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_hosts_file/exec_env/execution-environment.yml
@@ -1,0 +1,13 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner
+  system:
+    - podman

--- a/extensions/patterns/manage_hosts_file/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_hosts_file/exec_env/execution-environment.yml
@@ -9,5 +9,3 @@ dependencies:
     package_pip: ansible-core
   ansible_runner:
     package_pip: ansible-runner
-  system:
-    - podman

--- a/extensions/patterns/manage_hosts_file/exec_env/requirements.yml
+++ b/extensions/patterns/manage_hosts_file/exec_env/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  # - name: ansible.experience_demo
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_hosts_file/exec_env/requirements.yml
+++ b/extensions/patterns/manage_hosts_file/exec_env/requirements.yml
@@ -1,6 +1,5 @@
 ---
 collections:
-  # - name: ansible.experience_demo
   - name: https://github.com/redhat-cop/infra.windows_ops.git
     type: git
     version: main

--- a/extensions/patterns/manage_hosts_file/playbooks/run_manage_hosts_file.yml
+++ b/extensions/patterns/manage_hosts_file/playbooks/run_manage_hosts_file.yml
@@ -7,6 +7,6 @@
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_hosts_file
       vars:
-        windows_manage_hosts_file_entries: "{{ hosts_file_entries | default([]) | split('\n') if hosts_file_entries is string else hosts_file_entries | default([]) }}"  # Set by survey
+        windows_manage_hosts_file_entries: "{{ (hosts_file_entries.split('\n') | reject('equalto', '') | list) if hosts_file_entries is string and hosts_file_entries | length > 0 else (hosts_file_entries if hosts_file_entries is not string else []) | default([]) }}"  # Set by survey
         windows_manage_hosts_file_self_add: "{{ hosts_file_self_add | default(false) | bool }}"  # Set by survey
 ...

--- a/extensions/patterns/manage_hosts_file/playbooks/run_manage_hosts_file.yml
+++ b/extensions/patterns/manage_hosts_file/playbooks/run_manage_hosts_file.yml
@@ -1,0 +1,12 @@
+---
+- name: Manage Windows Hosts File
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Configure hosts file
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_hosts_file
+      vars:
+        windows_manage_hosts_file_entries: "{{ hosts_file_entries | default([]) | split('\n') if hosts_file_entries is string else hosts_file_entries | default([]) }}"  # Set by survey
+        windows_manage_hosts_file_self_add: "{{ hosts_file_self_add | default(false) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_hosts_file/setup.yml
+++ b/extensions/patterns/manage_hosts_file/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_hosts_file_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_hosts_file
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/p3ck/apd-ee-25-experience:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of hosts file configurations.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of hosts file entries.
+    organization: Default
+    scm_branch: main
+    scm_clean: 'no'
+    scm_delete_on_update: 'no'
+    scm_type: git
+    scm_update_on_launch: 'yes'
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Hosts File
+    description: >
+      This job template manages hosts file configurations, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_hosts_file_pattern
+      - run_manage_hosts_file
+    playbook: "extensions/patterns/manage_hosts_file/playbooks/run_manage_hosts_file.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_hosts_file.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_hosts_file/setup.yml
+++ b/extensions/patterns/manage_hosts_file/setup.yml
@@ -14,7 +14,7 @@ controller_labels:
 controller_execution_environments:
   - name: apd-ee-25-windows
     description: Allow running Windows experience demo. Based on apd-ee-25.
-    image: quay.io/p3ck/apd-ee-25-experience:latest
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
     pull: always
 
 # Projects
@@ -27,10 +27,10 @@ controller_projects:
       seamless management of hosts file entries.
     organization: Default
     scm_branch: main
-    scm_clean: 'no'
-    scm_delete_on_update: 'no'
+    scm_clean: false
+    scm_delete_on_update: false
     scm_type: git
-    scm_update_on_launch: 'yes'
+    scm_update_on_launch: true
     scm_url: https://github.com/redhat-cop/infra.windows_ops.git
     credential: "{{ credential | default(omit, true) }}"
 

--- a/extensions/patterns/manage_hosts_file/template_surveys/manage_hosts_file.yml
+++ b/extensions/patterns/manage_hosts_file/template_surveys/manage_hosts_file.yml
@@ -1,0 +1,19 @@
+---
+name: "Manage Hosts File Configuration Survey"
+description: "Survey to configure hosts file options"
+spec:
+  - question_name: "Host Entries"
+    question_description: "Enter host entries, one per line (e.g., 192.168.1.10 app.example.com app)"
+    required: false
+    variable: "hosts_file_entries"
+    type: "textarea"
+
+  - question_name: "Add Self Entry"
+    question_description: "Add an entry for this host based on Ansible facts"
+    required: true
+    variable: "hosts_file_self_add"
+    type: "multiplechoice"
+    choices:
+      - "false"
+      - "true"
+    default: "false"

--- a/roles/windows_manage_hosts_file/README.md
+++ b/roles/windows_manage_hosts_file/README.md
@@ -1,0 +1,36 @@
+# windows_manage_hosts_file
+
+Manage the Windows hosts file with header, self-entry, custom entries, and IPv4/IPv6 filtering.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_hosts_file_header` | str | *(default Windows header)* | Header content for the hosts file |
+| `windows_manage_hosts_file_self_add` | bool | `false` | Add host self-entry from Ansible facts |
+| `windows_manage_hosts_file_self_domain` | str | `null` | Override domain for self-entry |
+| `windows_manage_hosts_file_entries` | list(str) | `[]` | Custom host entries (IP HOSTNAME format) |
+| `windows_manage_hosts_file_omit_entries` | str | `none` | Filter: `none`, `ipv4`, or `ipv6` |
+
+## Example Playbook
+
+```yaml
+- name: Configure hosts file
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_hosts_file
+      vars:
+        windows_manage_hosts_file_entries:
+          - "192.168.1.10    app.example.com app"
+          - "192.168.1.20    db.example.com db"
+        windows_manage_hosts_file_self_add: true
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_hosts_file/defaults/main.yml
+++ b/roles/windows_manage_hosts_file/defaults/main.yml
@@ -1,0 +1,41 @@
+---
+# Header to always apply (subject to windows_manage_hosts_file_omit_entries)
+windows_manage_hosts_file_header: |
+  #  Copyright (c) 1993-2009 Microsoft Corp.
+  #
+  # This is a sample HOSTS file used by Microsoft TCP/IP for Windows.
+  #
+  # This file contains the mappings of IP addresses to host names. Each
+  # entry should be kept on an individual line. The IP address should
+  # be placed in the first column followed by the corresponding host name.
+  # The IP address and the host name should be separated by at least one
+  # space.
+  #
+  # Additionally, comments (such as these) may be inserted on individual
+  # lines or following the machine name denoted by a '#' symbol.
+  #
+  # For example:
+  #
+  #      102.54.94.97     rhino.acme.com          # source server
+  #       38.25.63.10     x.acme.com              # x client host
+
+  # localhost name resolution is handled within DNS itself.
+  #	127.0.0.1       localhost
+  #	::1             localhost
+
+# Add entry for host itself based on Ansible facts
+# Uses the first IP address found in the system
+# Should be disabled when not using static IP
+windows_manage_hosts_file_self_add: false
+
+# Force domain name used in host self entry
+# If unset defaults to ansible_facts.domain
+# Required if ansible_facts.domain is empty
+windows_manage_hosts_file_self_domain:
+
+# List of lines to add to hosts file
+# Other entries will be removed
+windows_manage_hosts_file_entries: []
+
+# Entries to omit: none, ipv4, or ipv6
+windows_manage_hosts_file_omit_entries: none

--- a/roles/windows_manage_hosts_file/handlers/main.yml
+++ b/roles/windows_manage_hosts_file/handlers/main.yml
@@ -1,3 +1,4 @@
 ---
 - name: Flush DNS resolver cache
   ansible.windows.win_command: ipconfig.exe /flushdns
+  changed_when: false

--- a/roles/windows_manage_hosts_file/handlers/main.yml
+++ b/roles/windows_manage_hosts_file/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Flush DNS resolver cache
+  ansible.windows.win_command: ipconfig.exe /flushdns

--- a/roles/windows_manage_hosts_file/meta/argument_specs.yml
+++ b/roles/windows_manage_hosts_file/meta/argument_specs.yml
@@ -1,0 +1,47 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Manage Windows hosts file.
+    description:
+      - Manage the Windows hosts file with header, self-entry, and custom entries.
+      - Supports selective IPv4 or IPv6 entry filtering.
+      - Automatically flushes the DNS resolver cache after changes.
+    options:
+      windows_manage_hosts_file_header:
+        type: str
+        description:
+          - Header content for the hosts file.
+          - Applied subject to I(windows_manage_hosts_file_omit_entries) filtering.
+        required: false
+      windows_manage_hosts_file_self_add:
+        type: bool
+        description:
+          - Add an entry for the host itself based on Ansible facts.
+          - Uses the first IPv4 and IPv6 addresses found on the system.
+          - Should be disabled when not using static IP addresses.
+        default: false
+      windows_manage_hosts_file_self_domain:
+        type: str
+        description:
+          - Override domain name used in the host self-entry.
+          - Defaults to C(ansible_facts.domain) if not set.
+          - Required if C(ansible_facts.domain) is empty and I(windows_manage_hosts_file_self_add) is true.
+        required: false
+      windows_manage_hosts_file_entries:
+        type: list
+        elements: str
+        description:
+          - List of lines to add to the hosts file.
+          - Each line should be in the format C(IP_ADDRESS HOSTNAME [ALIAS...]).
+          - Existing entries not in this list will be removed.
+        default: []
+      windows_manage_hosts_file_omit_entries:
+        type: str
+        description:
+          - Filter entries by address type.
+        default: none
+        choices:
+          - none
+          - ipv4
+          - ipv6

--- a/roles/windows_manage_hosts_file/meta/main.yml
+++ b/roles/windows_manage_hosts_file/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_hosts_file
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Manage Windows hosts file entries with optional self-entry and IPv4/IPv6 filtering.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - network
+    - configuration
+dependencies: []

--- a/roles/windows_manage_hosts_file/tasks/main.yml
+++ b/roles/windows_manage_hosts_file/tasks/main.yml
@@ -55,8 +55,4 @@
   ansible.windows.win_copy:
     content: "{{ _hosts_content }}"
     dest: C:\Windows\System32\drivers\etc\hosts
-  register: windows_manage_hosts_file_result
-
-- name: Flush DNS resolver cache
-  ansible.windows.win_command: ipconfig.exe /flushdns
-  when: windows_manage_hosts_file_result is changed
+  notify: Flush DNS resolver cache

--- a/roles/windows_manage_hosts_file/tasks/main.yml
+++ b/roles/windows_manage_hosts_file/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Validate omit_entries value
+  ansible.builtin.assert:
+    that:
+      - windows_manage_hosts_file_omit_entries in ['none', 'ipv4', 'ipv6']
+    fail_msg: >-
+      windows_manage_hosts_file_omit_entries must be 'none', 'ipv4', or 'ipv6',
+      got '{{ windows_manage_hosts_file_omit_entries }}'.
+
 - name: Gather needed facts
   ansible.windows.setup:
     gather_subset:
@@ -14,7 +22,9 @@
 
 - name: Fail if domainname not set for self entry
   ansible.builtin.fail:
-    msg: "No domainname set."
+    msg: >-
+      No domain name available. Set 'windows_manage_hosts_file_self_domain'
+      or ensure the host is domain-joined.
   when:
     - windows_manage_hosts_file_self_add | bool
     - not windows_manage_hosts_file_self_domain | default(ansible_facts.domain, true)

--- a/roles/windows_manage_hosts_file/tasks/main.yml
+++ b/roles/windows_manage_hosts_file/tasks/main.yml
@@ -20,39 +20,7 @@
     - not windows_manage_hosts_file_self_domain | default(ansible_facts.domain, true)
 
 - name: Create hosts file
-  vars:
-    _default_ipv4: "{{ ansible_facts.ip_addresses | map('regex_search', '^\\d+(\\.\\d+){3}$') | select | first }}"
-    _default_ipv6: "{{ ansible_facts.ip_addresses | map('regex_search', '.*:.*') | select | first }}"
-    _self_host: "{{ ansible_facts.hostname.split('.')[0] }}"
-    _self_domain: "{{ windows_manage_hosts_file_self_domain | default(ansible_facts.domain, true) }}"
-    _self_fqdn: "{{ _self_host + '.' + _self_domain }}"
-    _hosts_self: |
-      {% if windows_manage_hosts_file_self_add | bool and 'localhost' not in ansible_facts.hostname %}
-      {% if _self_domain != '' and
-            windows_manage_hosts_file_omit_entries != 'ipv4' and
-            _default_ipv4 is defined and
-            _default_ipv4 | length > 0 %}
-      {{ '%-16s' | format(_default_ipv4) }} {{ _self_fqdn }} {{ _self_host }}
-      {% endif %}
-      {% if _self_domain != '' and
-            windows_manage_hosts_file_omit_entries != 'ipv6' and
-            _default_ipv6 is defined and
-            _default_ipv6 | length > 0 %}
-      {{ '%-40s' | format(_default_ipv6) }} {{ _self_fqdn }} {{ _self_host }}
-      {% endif %}
-      {% endif %}
-    _hosts_content: |
-      {% for line in (windows_manage_hosts_file_header.split('\n') if windows_manage_hosts_file_header else ['omit']) +
-                     (_hosts_self.split('\n') if windows_manage_hosts_file_self_add | bool else ['omit']) +
-                     (windows_manage_hosts_file_entries | default(['omit'], true)) %}
-      {% if line !='omit' and
-            (windows_manage_hosts_file_omit_entries == 'none' or
-             (windows_manage_hosts_file_omit_entries == 'ipv4' and '.' not in line.split(' ')[0]) or
-             (windows_manage_hosts_file_omit_entries == 'ipv6' and ':' not in line.split(' ')[0])) %}
-      {{ line }}
-      {% endif %}
-      {% endfor %}
-  ansible.windows.win_copy:
-    content: "{{ _hosts_content }}"
+  ansible.windows.win_template:
+    src: hosts.j2
     dest: C:\Windows\System32\drivers\etc\hosts
   notify: Flush DNS resolver cache

--- a/roles/windows_manage_hosts_file/tasks/main.yml
+++ b/roles/windows_manage_hosts_file/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+- name: Gather needed facts
+  ansible.windows.setup:
+    gather_subset:
+      - '!all'
+      - '!min'
+      - network
+      - platform
+  when:
+    - windows_manage_hosts_file_self_add | bool
+    - ansible_facts.ip_addresses is not defined or
+      ansible_facts.hostname is not defined or
+      ansible_facts.domain is not defined
+
+- name: Fail if domainname not set for self entry
+  ansible.builtin.fail:
+    msg: "No domainname set."
+  when:
+    - windows_manage_hosts_file_self_add | bool
+    - not windows_manage_hosts_file_self_domain | default(ansible_facts.domain, true)
+
+- name: Create hosts file
+  vars:
+    _default_ipv4: "{{ ansible_facts.ip_addresses | map('regex_search', '^\\d+(\\.\\d+){3}$') | select | first }}"
+    _default_ipv6: "{{ ansible_facts.ip_addresses | map('regex_search', '.*:.*') | select | first }}"
+    _self_host: "{{ ansible_facts.hostname.split('.')[0] }}"
+    _self_domain: "{{ windows_manage_hosts_file_self_domain | default(ansible_facts.domain, true) }}"
+    _self_fqdn: "{{ _self_host + '.' + _self_domain }}"
+    _hosts_self: |
+      {% if windows_manage_hosts_file_self_add | bool and 'localhost' not in ansible_facts.hostname %}
+      {% if _self_domain != '' and
+            windows_manage_hosts_file_omit_entries != 'ipv4' and
+            _default_ipv4 is defined and
+            _default_ipv4 | length > 0 %}
+      {{ '%-16s' | format(_default_ipv4) }} {{ _self_fqdn }} {{ _self_host }}
+      {% endif %}
+      {% if _self_domain != '' and
+            windows_manage_hosts_file_omit_entries != 'ipv6' and
+            _default_ipv6 is defined and
+            _default_ipv6 | length > 0 %}
+      {{ '%-40s' | format(_default_ipv6) }} {{ _self_fqdn }} {{ _self_host }}
+      {% endif %}
+      {% endif %}
+    _hosts_content: |
+      {% for line in (windows_manage_hosts_file_header.split('\n') if windows_manage_hosts_file_header else ['omit']) +
+                     (_hosts_self.split('\n') if windows_manage_hosts_file_self_add | bool else ['omit']) +
+                     (windows_manage_hosts_file_entries | default(['omit'], true)) %}
+      {% if line !='omit' and
+            (windows_manage_hosts_file_omit_entries == 'none' or
+             (windows_manage_hosts_file_omit_entries == 'ipv4' and '.' not in line.split(' ')[0]) or
+             (windows_manage_hosts_file_omit_entries == 'ipv6' and ':' not in line.split(' ')[0])) %}
+      {{ line }}
+      {% endif %}
+      {% endfor %}
+  ansible.windows.win_copy:
+    content: "{{ _hosts_content }}"
+    dest: C:\Windows\System32\drivers\etc\hosts
+  register: windows_manage_hosts_file_result
+
+- name: Flush DNS resolver cache
+  ansible.windows.win_command: ipconfig.exe /flushdns
+  when: windows_manage_hosts_file_result is changed

--- a/roles/windows_manage_hosts_file/templates/hosts.j2
+++ b/roles/windows_manage_hosts_file/templates/hosts.j2
@@ -1,0 +1,29 @@
+{% if windows_manage_hosts_file_header %}
+{% for line in windows_manage_hosts_file_header.split('\n') %}
+{% if windows_manage_hosts_file_omit_entries == 'none' or
+      (windows_manage_hosts_file_omit_entries == 'ipv4' and '.' not in line.split(' ')[0]) or
+      (windows_manage_hosts_file_omit_entries == 'ipv6' and ':' not in line.split(' ')[0]) %}
+{{ line }}
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if windows_manage_hosts_file_self_add | bool and 'localhost' not in ansible_facts.hostname %}
+{% set _self_host = ansible_facts.hostname.split('.')[0] %}
+{% set _self_domain = windows_manage_hosts_file_self_domain | default(ansible_facts.domain, true) %}
+{% set _self_fqdn = _self_host + '.' + _self_domain %}
+{% set _default_ipv4 = ansible_facts.ip_addresses | map('regex_search', '^\d+(\.\d+){3}$') | select | first | default('') %}
+{% set _default_ipv6 = ansible_facts.ip_addresses | map('regex_search', '.*:.*') | select | first | default('') %}
+{% if _self_domain != '' and windows_manage_hosts_file_omit_entries != 'ipv4' and _default_ipv4 | length > 0 %}
+{{ '%-16s' | format(_default_ipv4) }} {{ _self_fqdn }} {{ _self_host }}
+{% endif %}
+{% if _self_domain != '' and windows_manage_hosts_file_omit_entries != 'ipv6' and _default_ipv6 | length > 0 %}
+{{ '%-40s' | format(_default_ipv6) }} {{ _self_fqdn }} {{ _self_host }}
+{% endif %}
+{% endif %}
+{% for line in windows_manage_hosts_file_entries | default([], true) %}
+{% if windows_manage_hosts_file_omit_entries == 'none' or
+      (windows_manage_hosts_file_omit_entries == 'ipv4' and '.' not in line.split(' ')[0]) or
+      (windows_manage_hosts_file_omit_entries == 'ipv6' and ':' not in line.split(' ')[0]) %}
+{{ line }}
+{% endif %}
+{% endfor %}

--- a/roles/windows_manage_hosts_file/templates/hosts.j2
+++ b/roles/windows_manage_hosts_file/templates/hosts.j2
@@ -1,6 +1,7 @@
 {% if windows_manage_hosts_file_header %}
 {% for line in windows_manage_hosts_file_header.split('\n') %}
-{% if windows_manage_hosts_file_omit_entries == 'none' or
+{% if line.strip().startswith('#') or
+      windows_manage_hosts_file_omit_entries == 'none' or
       (windows_manage_hosts_file_omit_entries == 'ipv4' and '.' not in line.split(' ')[0]) or
       (windows_manage_hosts_file_omit_entries == 'ipv6' and ':' not in line.split(' ')[0]) %}
 {{ line }}

--- a/tests/integration/targets/windows_ops_test_windows_manage_hosts_file/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_hosts_file/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_hosts_file/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_hosts_file/defaults/main.yml
@@ -3,3 +3,7 @@ windows_manage_hosts_file_test_entries_a:
   - "198.51.100.10   test-host-a.example.com test-host-a"
 windows_manage_hosts_file_test_entries_b:
   - "203.0.113.20    test-host-b.example.com test-host-b"
+
+windows_manage_hosts_file_test_entries_mixed:
+  - "198.51.100.30   ipv4-only.example.com ipv4-only"
+  - "fd00::30        ipv6-only.example.com ipv6-only"

--- a/tests/integration/targets/windows_ops_test_windows_manage_hosts_file/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_hosts_file/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+windows_manage_hosts_file_test_entries_a:
+  - "198.51.100.10   test-host-a.example.com test-host-a"
+windows_manage_hosts_file_test_entries_b:
+  - "203.0.113.20    test-host-b.example.com test-host-b"

--- a/tests/integration/targets/windows_ops_test_windows_manage_hosts_file/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_hosts_file/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+- name: Test hosts file configuration
+  block:
+    - name: Capture original hosts file
+      ansible.windows.win_shell: |
+        Get-Content C:\Windows\System32\drivers\etc\hosts -Raw
+      register: windows_manage_hosts_file_original_raw
+      changed_when: false
+
+    - name: Record original hosts file content
+      ansible.builtin.set_fact:
+        windows_manage_hosts_file_original_content: "{{ windows_manage_hosts_file_original_raw.stdout }}"
+
+    - name: Configure hosts file (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_hosts_file
+      vars:
+        windows_manage_hosts_file_entries: "{{ windows_manage_hosts_file_test_entries_a }}"
+
+    - name: Verify hosts file contains state A entry
+      ansible.windows.win_shell: |
+        Select-String -Path C:\Windows\System32\drivers\etc\hosts -Pattern 'test-host-a' -Quiet
+      register: windows_manage_hosts_file_verify_a
+      changed_when: false
+
+    - name: Assert state A entry exists
+      ansible.builtin.assert:
+        that:
+          - "'True' in windows_manage_hosts_file_verify_a.stdout"
+        fail_msg: "Hosts file does not contain state A entry"
+
+    - name: Run role again to verify idempotency (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_hosts_file
+      vars:
+        windows_manage_hosts_file_entries: "{{ windows_manage_hosts_file_test_entries_a }}"
+
+    - name: Configure hosts file (state B)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_hosts_file
+      vars:
+        windows_manage_hosts_file_entries: "{{ windows_manage_hosts_file_test_entries_b }}"
+
+    - name: Verify hosts file contains state B entry
+      ansible.windows.win_shell: |
+        Select-String -Path C:\Windows\System32\drivers\etc\hosts -Pattern 'test-host-b' -Quiet
+      register: windows_manage_hosts_file_verify_b
+      changed_when: false
+
+    - name: Assert state B entry exists
+      ansible.builtin.assert:
+        that:
+          - "'True' in windows_manage_hosts_file_verify_b.stdout"
+        fail_msg: "Hosts file does not contain state B entry"
+
+    - name: Verify state A entry was replaced
+      ansible.windows.win_shell: |
+        Select-String -Path C:\Windows\System32\drivers\etc\hosts -Pattern 'test-host-a' -Quiet
+      register: windows_manage_hosts_file_verify_a_gone
+      changed_when: false
+
+    - name: Assert state A entry no longer exists
+      ansible.builtin.assert:
+        that:
+          - "'True' not in windows_manage_hosts_file_verify_a_gone.stdout"
+        fail_msg: "State A entry was not replaced by state B"
+
+  always:
+    - name: Restore original hosts file
+      ansible.windows.win_copy:
+        content: "{{ windows_manage_hosts_file_original_content }}"
+        dest: C:\Windows\System32\drivers\etc\hosts
+
+    - name: Flush DNS after restore
+      ansible.windows.win_command: ipconfig.exe /flushdns

--- a/tests/integration/targets/windows_ops_test_windows_manage_hosts_file/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_hosts_file/tasks/main.yml
@@ -11,6 +11,7 @@
       ansible.builtin.set_fact:
         windows_manage_hosts_file_original_content: "{{ windows_manage_hosts_file_original_raw.stdout }}"
 
+    # -- A/B state test --
     - name: Configure hosts file (state A)
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_hosts_file
@@ -29,12 +30,32 @@
           - "'True' in windows_manage_hosts_file_verify_a.stdout"
         fail_msg: "Hosts file does not contain state A entry"
 
+    # -- Idempotency test --
+    - name: Capture hosts file after state A
+      ansible.windows.win_shell: |
+        Get-Content C:\Windows\System32\drivers\etc\hosts -Raw
+      register: windows_manage_hosts_file_state_a_content
+      changed_when: false
+
     - name: Run role again to verify idempotency (state A)
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_hosts_file
       vars:
         windows_manage_hosts_file_entries: "{{ windows_manage_hosts_file_test_entries_a }}"
 
+    - name: Capture hosts file after idempotency re-run
+      ansible.windows.win_shell: |
+        Get-Content C:\Windows\System32\drivers\etc\hosts -Raw
+      register: windows_manage_hosts_file_idempotent_content
+      changed_when: false
+
+    - name: Assert hosts file unchanged after idempotency re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_hosts_file_state_a_content.stdout == windows_manage_hosts_file_idempotent_content.stdout
+        fail_msg: "Role is not idempotent - hosts file content changed on re-run"
+
+    # -- State B replaces state A --
     - name: Configure hosts file (state B)
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_hosts_file
@@ -64,6 +85,101 @@
         that:
           - "'True' not in windows_manage_hosts_file_verify_a_gone.stdout"
         fail_msg: "State A entry was not replaced by state B"
+
+    # -- self_add test --
+    - name: Gather facts for self_add test
+      ansible.windows.setup:
+        gather_subset:
+          - '!all'
+          - '!min'
+          - network
+          - platform
+      register: windows_manage_hosts_file_test_facts
+
+    - name: Configure hosts file with self_add enabled
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_hosts_file
+      vars:
+        windows_manage_hosts_file_self_add: true
+        windows_manage_hosts_file_entries: []
+
+    - name: Read hosts file after self_add
+      ansible.windows.win_shell: |
+        Get-Content C:\Windows\System32\drivers\etc\hosts -Raw
+      register: windows_manage_hosts_file_self_add_result
+      changed_when: false
+
+    - name: Assert self entry contains hostname
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.hostname in windows_manage_hosts_file_self_add_result.stdout
+        fail_msg: >-
+          Hosts file does not contain self entry for {{ ansible_facts.hostname }}
+      when: ansible_facts.domain | default('') | length > 0
+
+    # -- omit_entries test --
+    - name: Configure hosts file with mixed entries (no filter)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_hosts_file
+      vars:
+        windows_manage_hosts_file_self_add: false
+        windows_manage_hosts_file_entries: "{{ windows_manage_hosts_file_test_entries_mixed }}"
+        windows_manage_hosts_file_omit_entries: none
+
+    - name: Read hosts file with no filter
+      ansible.windows.win_shell: |
+        Get-Content C:\Windows\System32\drivers\etc\hosts -Raw
+      register: windows_manage_hosts_file_no_filter_result
+      changed_when: false
+
+    - name: Assert both IPv4 and IPv6 entries present with no filter
+      ansible.builtin.assert:
+        that:
+          - "'ipv4-only' in windows_manage_hosts_file_no_filter_result.stdout"
+          - "'ipv6-only' in windows_manage_hosts_file_no_filter_result.stdout"
+        fail_msg: "Both entries should be present when omit_entries is 'none'"
+
+    - name: Configure hosts file omitting IPv6
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_hosts_file
+      vars:
+        windows_manage_hosts_file_self_add: false
+        windows_manage_hosts_file_entries: "{{ windows_manage_hosts_file_test_entries_mixed }}"
+        windows_manage_hosts_file_omit_entries: ipv6
+
+    - name: Read hosts file after omitting IPv6
+      ansible.windows.win_shell: |
+        Get-Content C:\Windows\System32\drivers\etc\hosts -Raw
+      register: windows_manage_hosts_file_omit_ipv6_result
+      changed_when: false
+
+    - name: Assert IPv4 present and IPv6 omitted
+      ansible.builtin.assert:
+        that:
+          - "'ipv4-only' in windows_manage_hosts_file_omit_ipv6_result.stdout"
+          - "'ipv6-only' not in windows_manage_hosts_file_omit_ipv6_result.stdout"
+        fail_msg: "omit_entries 'ipv6' should keep IPv4 and remove IPv6"
+
+    - name: Configure hosts file omitting IPv4
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_hosts_file
+      vars:
+        windows_manage_hosts_file_self_add: false
+        windows_manage_hosts_file_entries: "{{ windows_manage_hosts_file_test_entries_mixed }}"
+        windows_manage_hosts_file_omit_entries: ipv4
+
+    - name: Read hosts file after omitting IPv4
+      ansible.windows.win_shell: |
+        Get-Content C:\Windows\System32\drivers\etc\hosts -Raw
+      register: windows_manage_hosts_file_omit_ipv4_result
+      changed_when: false
+
+    - name: Assert IPv6 present and IPv4 omitted
+      ansible.builtin.assert:
+        that:
+          - "'ipv6-only' in windows_manage_hosts_file_omit_ipv4_result.stdout"
+          - "'ipv4-only' not in windows_manage_hosts_file_omit_ipv4_result.stdout"
+        fail_msg: "omit_entries 'ipv4' should keep IPv6 and remove IPv4"
 
   always:
     - name: Restore original hosts file


### PR DESCRIPTION
##### SUMMARY
Add new `windows_manage_hosts_file` role for managing the Windows hosts file.

- Manages the complete hosts file content using `ansible.windows.win_copy` with Jinja2 templating
- Supports custom header, self-entry from Ansible facts, and custom host entries
- Selective IPv4/IPv6 entry filtering via `omit_entries` parameter
- Automatically flushes DNS resolver cache after changes
- Includes integration tests with two-state verification (entry A → entry B → verify replacement → restore)
- Includes AAP pattern (setup, playbook, survey, execution environment)
- Includes changelog fragment

Part of ACA-2792 Batch 2 (Network and Remote Access).

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
roles/windows_manage_hosts_file