### PR TITLE
feat(windows_manage_rdp): add role for RDP configuration

### DIFF
--- a/changelogs/fragments/add-windows-manage-rdp.yml
+++ b/changelogs/fragments/add-windows-manage-rdp.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_rdp - new role for enabling or disabling Remote Desktop Protocol with firewall and authentication settings."

--- a/changelogs/fragments/add-windows-manage-rdp.yml
+++ b/changelogs/fragments/add-windows-manage-rdp.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - "windows_manage_rdp - new role for enabling or disabling Remote Desktop Protocol with firewall and authentication settings."
+  - "windows_manage_rdp - new role for enabling or disabling Remote Desktop Protocol with firewall and authentication settings
+    (https://github.com/redhat-cop/infra.windows_ops/pull/73)."

--- a/extensions/patterns/manage_rdp/exec_env/README.md
+++ b/extensions/patterns/manage_rdp/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/p3ck/apd-ee-25-experience:latest
+podman push quay.io/p3ck/apd-ee-25-experience:latest
+```

--- a/extensions/patterns/manage_rdp/exec_env/README.md
+++ b/extensions/patterns/manage_rdp/exec_env/README.md
@@ -3,6 +3,6 @@ Build EE manually, push to quay.io
 ```
 ansible-builder build
 # podman build -f context/Containerfile -t ansible-execution-env:latest context
-podman tag ansible-execution-env:latest quay.io/p3ck/apd-ee-25-experience:latest
-podman push quay.io/p3ck/apd-ee-25-experience:latest
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
 ```

--- a/extensions/patterns/manage_rdp/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_rdp/exec_env/execution-environment.yml
@@ -1,0 +1,13 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner
+  system:
+    - podman

--- a/extensions/patterns/manage_rdp/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_rdp/exec_env/execution-environment.yml
@@ -9,5 +9,3 @@ dependencies:
     package_pip: ansible-core
   ansible_runner:
     package_pip: ansible-runner
-  system:
-    - podman

--- a/extensions/patterns/manage_rdp/exec_env/requirements.yml
+++ b/extensions/patterns/manage_rdp/exec_env/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  # - name: ansible.experience_demo
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_rdp/exec_env/requirements.yml
+++ b/extensions/patterns/manage_rdp/exec_env/requirements.yml
@@ -1,6 +1,5 @@
 ---
 collections:
-  # - name: ansible.experience_demo
   - name: https://github.com/redhat-cop/infra.windows_ops.git
     type: git
     version: main

--- a/extensions/patterns/manage_rdp/playbooks/run_manage_rdp.yml
+++ b/extensions/patterns/manage_rdp/playbooks/run_manage_rdp.yml
@@ -1,0 +1,12 @@
+---
+- name: Manage Windows RDP Configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Configure RDP
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_rdp
+      vars:
+        windows_manage_rdp_enable: "{{ rdp_enable | default(true) | bool }}"  # Set by survey
+        windows_manage_rdp_authenticate: "{{ rdp_authenticate | default(true) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_rdp/setup.yml
+++ b/extensions/patterns/manage_rdp/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_rdp_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_rdp
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/p3ck/apd-ee-25-experience:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of RDP configurations.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of RDP settings.
+    organization: Default
+    scm_branch: main
+    scm_clean: 'no'
+    scm_delete_on_update: 'no'
+    scm_type: git
+    scm_update_on_launch: 'yes'
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage RDP
+    description: >
+      This job template manages RDP configurations, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_rdp_pattern
+      - run_manage_rdp
+    playbook: "extensions/patterns/manage_rdp/playbooks/run_manage_rdp.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_rdp.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_rdp/setup.yml
+++ b/extensions/patterns/manage_rdp/setup.yml
@@ -14,7 +14,7 @@ controller_labels:
 controller_execution_environments:
   - name: apd-ee-25-windows
     description: Allow running Windows experience demo. Based on apd-ee-25.
-    image: quay.io/p3ck/apd-ee-25-experience:latest
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
     pull: always
 
 # Projects
@@ -27,10 +27,10 @@ controller_projects:
       seamless management of RDP settings.
     organization: Default
     scm_branch: main
-    scm_clean: 'no'
-    scm_delete_on_update: 'no'
+    scm_clean: false
+    scm_delete_on_update: false
     scm_type: git
-    scm_update_on_launch: 'yes'
+    scm_update_on_launch: true
     scm_url: https://github.com/redhat-cop/infra.windows_ops.git
     credential: "{{ credential | default(omit, true) }}"
 

--- a/extensions/patterns/manage_rdp/template_surveys/manage_rdp.yml
+++ b/extensions/patterns/manage_rdp/template_surveys/manage_rdp.yml
@@ -1,0 +1,23 @@
+---
+name: "Manage RDP Configuration Survey"
+description: "Survey to configure RDP options"
+spec:
+  - question_name: "Enable RDP"
+    question_description: "Enable or disable Remote Desktop Protocol connections"
+    required: true
+    variable: "rdp_enable"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Require Authentication"
+    question_description: "Require Network Level Authentication (NLA) for RDP connections"
+    required: true
+    variable: "rdp_authenticate"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"

--- a/roles/windows_manage_rdp/README.md
+++ b/roles/windows_manage_rdp/README.md
@@ -1,0 +1,37 @@
+# windows_manage_rdp
+
+Enable or disable Remote Desktop Protocol (RDP) with firewall and authentication settings.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+- `community.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_rdp_enable` | bool | `true` | Enable or disable RDP connections |
+| `windows_manage_rdp_firewall_profiles` | list(str) | `[domain, private]` | Firewall profiles for RDP rules |
+| `windows_manage_rdp_authenticate` | bool | `true` | Require Network Level Authentication (NLA) |
+
+## Example Playbook
+
+```yaml
+- name: Configure RDP
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_rdp
+      vars:
+        windows_manage_rdp_enable: true
+        windows_manage_rdp_authenticate: true
+        windows_manage_rdp_firewall_profiles:
+          - domain
+          - private
+          - public
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_rdp/defaults/main.yml
+++ b/roles/windows_manage_rdp/defaults/main.yml
@@ -3,9 +3,15 @@
 windows_manage_rdp_enable: true
 
 # Firewall profiles to apply rules
+# Includes all profiles to ensure complete coverage when disabling
 windows_manage_rdp_firewall_profiles:
   - domain
   - private
+  - public
 
-# Require authentication for RDP
+# Require Network Level Authentication (NLA) for RDP connections.
+# WARNING: Setting this to false disables NLA, allowing any user to reach
+# the Windows login screen without pre-authentication. This significantly
+# increases attack surface and has historically enabled unauthenticated
+# RCE vulnerabilities (e.g., BlueKeep CVE-2019-0708).
 windows_manage_rdp_authenticate: true

--- a/roles/windows_manage_rdp/defaults/main.yml
+++ b/roles/windows_manage_rdp/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# Enable or disable RDP
+windows_manage_rdp_enable: true
+
+# Firewall profiles to apply rules
+windows_manage_rdp_firewall_profiles:
+  - domain
+  - private
+
+# Require authentication for RDP
+windows_manage_rdp_authenticate: true

--- a/roles/windows_manage_rdp/meta/argument_specs.yml
+++ b/roles/windows_manage_rdp/meta/argument_specs.yml
@@ -17,11 +17,15 @@ argument_specs:
         elements: str
         description:
           - Firewall profiles to apply RDP rules to.
+          - Valid values are C(domain), C(private), and C(public).
         default:
           - domain
           - private
+          - public
       windows_manage_rdp_authenticate:
         type: bool
         description:
           - Require Network Level Authentication (NLA) for RDP connections.
+          - "B(WARNING): Setting this to C(false) disables NLA, exposing the
+            Windows login screen to unauthenticated network access."
         default: true

--- a/roles/windows_manage_rdp/meta/argument_specs.yml
+++ b/roles/windows_manage_rdp/meta/argument_specs.yml
@@ -1,0 +1,27 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Configure Windows RDP settings.
+    description:
+      - Enable or disable Remote Desktop Protocol (RDP) on Windows hosts.
+      - Manages the RDP registry setting, firewall rules, and user authentication.
+    options:
+      windows_manage_rdp_enable:
+        type: bool
+        description:
+          - Enable or disable RDP connections.
+        default: true
+      windows_manage_rdp_firewall_profiles:
+        type: list
+        elements: str
+        description:
+          - Firewall profiles to apply RDP rules to.
+        default:
+          - domain
+          - private
+      windows_manage_rdp_authenticate:
+        type: bool
+        description:
+          - Require Network Level Authentication (NLA) for RDP connections.
+        default: true

--- a/roles/windows_manage_rdp/meta/main.yml
+++ b/roles/windows_manage_rdp/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_rdp
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Enable or disable Remote Desktop Protocol (RDP) with firewall and authentication settings.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - rdp
+    - configuration
+dependencies: []

--- a/roles/windows_manage_rdp/tasks/main.yml
+++ b/roles/windows_manage_rdp/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Validate firewall profiles
+  ansible.builtin.assert:
+    that:
+      - windows_manage_rdp_firewall_profiles | difference(['domain', 'private', 'public']) | length == 0
+    fail_msg: >-
+      windows_manage_rdp_firewall_profiles contains invalid values:
+      {{ windows_manage_rdp_firewall_profiles | difference(['domain', 'private', 'public']) }}.
+      Valid values are 'domain', 'private', 'public'.
+
 - name: Disable RDP service
   ansible.windows.win_regedit:
     path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server

--- a/roles/windows_manage_rdp/tasks/main.yml
+++ b/roles/windows_manage_rdp/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+- name: Disable RDP service
+  ansible.windows.win_regedit:
+    path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server
+    name: fDenyTSConnections
+    type: dword
+    data: 1
+  when: not windows_manage_rdp_enable | bool
+
+- name: Block firewall RDP port
+  community.windows.win_firewall_rule:
+    name: Remote Desktop - User Mode (TCP-In)
+    state: present
+    enabled: true
+    action: block
+    direction: in
+    localport: 3389
+    protocol: tcp
+    profiles: "{{ windows_manage_rdp_firewall_profiles | default(omit, true) }}"
+  when: not windows_manage_rdp_enable | bool
+
+- name: Configure RDP user authentication
+  ansible.windows.win_regedit:
+    path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-TCP
+    name: UserAuthentication
+    type: dword
+    data: "{{ 1 if windows_manage_rdp_authenticate | bool else 0 }}"
+
+- name: Enable RDP service
+  ansible.windows.win_regedit:
+    path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server
+    name: fDenyTSConnections
+    type: dword
+    data: 0
+  when: windows_manage_rdp_enable | bool
+
+- name: Allow firewall RDP port
+  community.windows.win_firewall_rule:
+    name: Remote Desktop - User Mode (TCP-In)
+    state: present
+    enabled: true
+    action: allow
+    direction: in
+    localport: 3389
+    protocol: tcp
+    profiles: "{{ windows_manage_rdp_firewall_profiles | default(omit, true) }}"
+  when: windows_manage_rdp_enable | bool

--- a/roles/windows_manage_rdp/tasks/main.yml
+++ b/roles/windows_manage_rdp/tasks/main.yml
@@ -7,7 +7,7 @@
     data: 1
   when: not windows_manage_rdp_enable | bool
 
-- name: Block firewall RDP port
+- name: Block firewall RDP TCP port
   community.windows.win_firewall_rule:
     name: Remote Desktop - User Mode (TCP-In)
     state: present
@@ -16,6 +16,18 @@
     direction: in
     localport: 3389
     protocol: tcp
+    profiles: "{{ windows_manage_rdp_firewall_profiles | default(omit, true) }}"
+  when: not windows_manage_rdp_enable | bool
+
+- name: Block firewall RDP UDP port
+  community.windows.win_firewall_rule:
+    name: Remote Desktop - User Mode (UDP-In)
+    state: present
+    enabled: true
+    action: block
+    direction: in
+    localport: 3389
+    protocol: udp
     profiles: "{{ windows_manage_rdp_firewall_profiles | default(omit, true) }}"
   when: not windows_manage_rdp_enable | bool
 
@@ -35,7 +47,7 @@
     data: 0
   when: windows_manage_rdp_enable | bool
 
-- name: Allow firewall RDP port
+- name: Allow firewall RDP TCP port
   community.windows.win_firewall_rule:
     name: Remote Desktop - User Mode (TCP-In)
     state: present
@@ -44,5 +56,17 @@
     direction: in
     localport: 3389
     protocol: tcp
+    profiles: "{{ windows_manage_rdp_firewall_profiles | default(omit, true) }}"
+  when: windows_manage_rdp_enable | bool
+
+- name: Allow firewall RDP UDP port
+  community.windows.win_firewall_rule:
+    name: Remote Desktop - User Mode (UDP-In)
+    state: present
+    enabled: true
+    action: allow
+    direction: in
+    localport: 3389
+    protocol: udp
     profiles: "{{ windows_manage_rdp_firewall_profiles | default(omit, true) }}"
   when: windows_manage_rdp_enable | bool

--- a/roles/windows_manage_rdp/tasks/main.yml
+++ b/roles/windows_manage_rdp/tasks/main.yml
@@ -25,6 +25,7 @@
     name: UserAuthentication
     type: dword
     data: "{{ 1 if windows_manage_rdp_authenticate | bool else 0 }}"
+  when: windows_manage_rdp_enable | bool
 
 - name: Enable RDP service
   ansible.windows.win_regedit:

--- a/tests/integration/targets/windows_ops_test_windows_manage_rdp/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_rdp/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_rdp/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_rdp/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Test verifies RDP enable + authentication toggle
+# RDP stays enabled throughout to avoid lockout risk

--- a/tests/integration/targets/windows_ops_test_windows_manage_rdp/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_rdp/tasks/main.yml
@@ -13,11 +13,23 @@
         name: fDenyTSConnections
       register: windows_manage_rdp_original_deny
 
+    - name: Capture original firewall TCP rule
+      community.windows.win_firewall_rule:
+        name: Remote Desktop - User Mode (TCP-In)
+        state: present
+        enabled: true
+        direction: in
+        localport: 3389
+        protocol: tcp
+      check_mode: true
+      register: windows_manage_rdp_original_fw_tcp
+
     - name: Record original values
       ansible.builtin.set_fact:
         windows_manage_rdp_original_auth_data: "{{ windows_manage_rdp_original_auth.value | default(1) }}"
         windows_manage_rdp_original_deny_data: "{{ windows_manage_rdp_original_deny.value | default(0) }}"
 
+    # -- State A: enable RDP, auth disabled --
     - name: Configure RDP (state A - authentication disabled)
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_rdp
@@ -49,6 +61,7 @@
           - windows_manage_rdp_verify_auth_a.value == 0
         fail_msg: "RDP authentication was not disabled"
 
+    # -- Idempotency test --
     - name: Run role again to verify idempotency (state A)
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_rdp
@@ -56,6 +69,26 @@
         windows_manage_rdp_enable: true
         windows_manage_rdp_authenticate: false
 
+    - name: Verify RDP still enabled after idempotent re-run
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server
+        name: fDenyTSConnections
+      register: windows_manage_rdp_verify_idempotent
+
+    - name: Verify auth still disabled after idempotent re-run
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-TCP
+        name: UserAuthentication
+      register: windows_manage_rdp_verify_auth_idempotent
+
+    - name: Assert state unchanged after idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_rdp_verify_idempotent.value == 0
+          - windows_manage_rdp_verify_auth_idempotent.value == 0
+        fail_msg: "Role is not idempotent - registry values changed on re-run"
+
+    # -- State B: enable RDP, auth enabled --
     - name: Configure RDP (state B - authentication enabled)
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_rdp
@@ -75,6 +108,44 @@
           - windows_manage_rdp_verify_auth_b.value == 1
         fail_msg: "RDP authentication was not enabled"
 
+    # -- RDP disable test (safe: connection is WinRM, not RDP) --
+    - name: Disable RDP
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_rdp
+      vars:
+        windows_manage_rdp_enable: false
+
+    - name: Verify RDP is disabled
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server
+        name: fDenyTSConnections
+      register: windows_manage_rdp_verify_disabled
+
+    - name: Assert RDP is disabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_rdp_verify_disabled.value == 1
+        fail_msg: "RDP was not disabled"
+
+    - name: Re-enable RDP to verify toggle works
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_rdp
+      vars:
+        windows_manage_rdp_enable: true
+        windows_manage_rdp_authenticate: true
+
+    - name: Verify RDP re-enabled
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server
+        name: fDenyTSConnections
+      register: windows_manage_rdp_verify_reenabled
+
+    - name: Assert RDP is re-enabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_rdp_verify_reenabled.value == 0
+        fail_msg: "RDP was not re-enabled after disable"
+
   always:
     - name: Restore original RDP enabled state
       ansible.windows.win_regedit:
@@ -89,3 +160,16 @@
         name: UserAuthentication
         type: dword
         data: "{{ windows_manage_rdp_original_auth_data }}"
+
+    - name: Restore firewall rules to allow RDP
+      community.windows.win_firewall_rule:
+        name: "{{ item.name }}"
+        state: present
+        enabled: true
+        action: allow
+        direction: in
+        localport: 3389
+        protocol: "{{ item.protocol }}"
+      loop:
+        - { name: "Remote Desktop - User Mode (TCP-In)", protocol: tcp }
+        - { name: "Remote Desktop - User Mode (UDP-In)", protocol: udp }

--- a/tests/integration/targets/windows_ops_test_windows_manage_rdp/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_rdp/tasks/main.yml
@@ -1,15 +1,22 @@
 ---
 - name: Test RDP configuration
   block:
-    - name: Capture original RDP authentication setting
+    - name: Capture original RDP settings
       ansible.windows.win_reg_stat:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-TCP
         name: UserAuthentication
       register: windows_manage_rdp_original_auth
 
-    - name: Record original authentication value
+    - name: Capture original RDP enabled state
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server
+        name: fDenyTSConnections
+      register: windows_manage_rdp_original_deny
+
+    - name: Record original values
       ansible.builtin.set_fact:
         windows_manage_rdp_original_auth_data: "{{ windows_manage_rdp_original_auth.value | default(1) }}"
+        windows_manage_rdp_original_deny_data: "{{ windows_manage_rdp_original_deny.value | default(0) }}"
 
     - name: Configure RDP (state A - authentication disabled)
       ansible.builtin.include_role:
@@ -69,6 +76,13 @@
         fail_msg: "RDP authentication was not enabled"
 
   always:
+    - name: Restore original RDP enabled state
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server
+        name: fDenyTSConnections
+        type: dword
+        data: "{{ windows_manage_rdp_original_deny_data }}"
+
     - name: Restore original authentication setting
       ansible.windows.win_regedit:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-TCP

--- a/tests/integration/targets/windows_ops_test_windows_manage_rdp/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_rdp/tasks/main.yml
@@ -1,0 +1,77 @@
+---
+- name: Test RDP configuration
+  block:
+    - name: Capture original RDP authentication setting
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-TCP
+        name: UserAuthentication
+      register: windows_manage_rdp_original_auth
+
+    - name: Record original authentication value
+      ansible.builtin.set_fact:
+        windows_manage_rdp_original_auth_data: "{{ windows_manage_rdp_original_auth.value | default(1) }}"
+
+    - name: Configure RDP (state A - authentication disabled)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_rdp
+      vars:
+        windows_manage_rdp_enable: true
+        windows_manage_rdp_authenticate: false
+
+    - name: Verify RDP is enabled after state A
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server
+        name: fDenyTSConnections
+      register: windows_manage_rdp_verify_enabled_a
+
+    - name: Assert RDP is enabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_rdp_verify_enabled_a.value == 0
+        fail_msg: "RDP was not enabled"
+
+    - name: Verify authentication disabled after state A
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-TCP
+        name: UserAuthentication
+      register: windows_manage_rdp_verify_auth_a
+
+    - name: Assert authentication is disabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_rdp_verify_auth_a.value == 0
+        fail_msg: "RDP authentication was not disabled"
+
+    - name: Run role again to verify idempotency (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_rdp
+      vars:
+        windows_manage_rdp_enable: true
+        windows_manage_rdp_authenticate: false
+
+    - name: Configure RDP (state B - authentication enabled)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_rdp
+      vars:
+        windows_manage_rdp_enable: true
+        windows_manage_rdp_authenticate: true
+
+    - name: Verify authentication enabled after state B
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-TCP
+        name: UserAuthentication
+      register: windows_manage_rdp_verify_auth_b
+
+    - name: Assert authentication is enabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_rdp_verify_auth_b.value == 1
+        fail_msg: "RDP authentication was not enabled"
+
+  always:
+    - name: Restore original authentication setting
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-TCP
+        name: UserAuthentication
+        type: dword
+        data: "{{ windows_manage_rdp_original_auth_data }}"


### PR DESCRIPTION
##### SUMMARY
Add new `windows_manage_rdp` role for managing Remote Desktop Protocol settings.

- Enable/disable RDP via registry (`fDenyTSConnections`)
- Manage firewall rules for RDP port 3389 using `community.windows.win_firewall_rule`
- Configure Network Level Authentication (NLA) requirement
- Fixes upstream bug: corrected `winrm_configuration_firewall_profiles` → `windows_manage_rdp_firewall_profiles`
- Includes integration tests with two-state verification (NLA toggle) and restore
- Includes AAP pattern (setup, playbook, survey, execution environment)
- Includes changelog fragment

Part of ACA-2792 Batch 2 (Network and Remote Access).

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
roles/windows_manage_rdp