### PR TITLE
feat(windows_manage_winrm): add role for WinRM configuration

### DIFF
--- a/changelogs/fragments/add-windows-manage-winrm.yml
+++ b/changelogs/fragments/add-windows-manage-winrm.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
-  - "windows_manage_winrm - new role for configuring Windows Remote Management service, listeners, and firewall rules."
+  - "windows_manage_winrm - new role for configuring Windows Remote Management service, listeners, and firewall rules
+    (https://github.com/redhat-cop/infra.windows_ops/pull/74)."

--- a/changelogs/fragments/add-windows-manage-winrm.yml
+++ b/changelogs/fragments/add-windows-manage-winrm.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_winrm - new role for configuring Windows Remote Management service, listeners, and firewall rules."

--- a/extensions/patterns/manage_winrm/exec_env/README.md
+++ b/extensions/patterns/manage_winrm/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/p3ck/apd-ee-25-experience:latest
+podman push quay.io/p3ck/apd-ee-25-experience:latest
+```

--- a/extensions/patterns/manage_winrm/exec_env/README.md
+++ b/extensions/patterns/manage_winrm/exec_env/README.md
@@ -3,6 +3,6 @@ Build EE manually, push to quay.io
 ```
 ansible-builder build
 # podman build -f context/Containerfile -t ansible-execution-env:latest context
-podman tag ansible-execution-env:latest quay.io/p3ck/apd-ee-25-experience:latest
-podman push quay.io/p3ck/apd-ee-25-experience:latest
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
 ```

--- a/extensions/patterns/manage_winrm/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_winrm/exec_env/execution-environment.yml
@@ -1,0 +1,13 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner
+  system:
+    - podman

--- a/extensions/patterns/manage_winrm/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_winrm/exec_env/execution-environment.yml
@@ -9,5 +9,3 @@ dependencies:
     package_pip: ansible-core
   ansible_runner:
     package_pip: ansible-runner
-  system:
-    - podman

--- a/extensions/patterns/manage_winrm/exec_env/requirements.yml
+++ b/extensions/patterns/manage_winrm/exec_env/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  # - name: ansible.experience_demo
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_winrm/exec_env/requirements.yml
+++ b/extensions/patterns/manage_winrm/exec_env/requirements.yml
@@ -1,6 +1,5 @@
 ---
 collections:
-  # - name: ansible.experience_demo
   - name: https://github.com/redhat-cop/infra.windows_ops.git
     type: git
     version: main

--- a/extensions/patterns/manage_winrm/playbooks/run_manage_winrm.yml
+++ b/extensions/patterns/manage_winrm/playbooks/run_manage_winrm.yml
@@ -1,0 +1,13 @@
+---
+- name: Manage Windows WinRM Configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Configure WinRM
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: "{{ winrm_enable | default(true) | bool }}"  # Set by survey
+        windows_manage_winrm_https_enable: "{{ winrm_https_enable | default(false) | bool }}"  # Set by survey
+        windows_manage_winrm_display_config: "{{ winrm_display_config | default(false) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_winrm/setup.yml
+++ b/extensions/patterns/manage_winrm/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_winrm_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_winrm
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/p3ck/apd-ee-25-experience:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of WinRM configurations.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of WinRM settings.
+    organization: Default
+    scm_branch: main
+    scm_clean: 'no'
+    scm_delete_on_update: 'no'
+    scm_type: git
+    scm_update_on_launch: 'yes'
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage WinRM
+    description: >
+      This job template manages WinRM configurations, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_winrm_pattern
+      - run_manage_winrm
+    playbook: "extensions/patterns/manage_winrm/playbooks/run_manage_winrm.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_winrm.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_winrm/setup.yml
+++ b/extensions/patterns/manage_winrm/setup.yml
@@ -14,7 +14,7 @@ controller_labels:
 controller_execution_environments:
   - name: apd-ee-25-windows
     description: Allow running Windows experience demo. Based on apd-ee-25.
-    image: quay.io/p3ck/apd-ee-25-experience:latest
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
     pull: always
 
 # Projects
@@ -27,10 +27,10 @@ controller_projects:
       seamless management of WinRM settings.
     organization: Default
     scm_branch: main
-    scm_clean: 'no'
-    scm_delete_on_update: 'no'
+    scm_clean: false
+    scm_delete_on_update: false
     scm_type: git
-    scm_update_on_launch: 'yes'
+    scm_update_on_launch: true
     scm_url: https://github.com/redhat-cop/infra.windows_ops.git
     credential: "{{ credential | default(omit, true) }}"
 

--- a/extensions/patterns/manage_winrm/template_surveys/manage_winrm.yml
+++ b/extensions/patterns/manage_winrm/template_surveys/manage_winrm.yml
@@ -1,0 +1,33 @@
+---
+name: "Manage WinRM Configuration Survey"
+description: "Survey to configure WinRM options"
+spec:
+  - question_name: "Enable WinRM"
+    question_description: "Enable or disable the WinRM service"
+    required: true
+    variable: "winrm_enable"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Enable HTTPS"
+    question_description: "Enable WinRM HTTPS listener with self-signed certificate"
+    required: true
+    variable: "winrm_https_enable"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Display Configuration"
+    question_description: "Display the current WinRM configuration after changes"
+    required: true
+    variable: "winrm_display_config"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"

--- a/roles/windows_manage_winrm/README.md
+++ b/roles/windows_manage_winrm/README.md
@@ -1,0 +1,50 @@
+# windows_manage_winrm
+
+Configure Windows Remote Management (WinRM) service, listeners, and firewall rules.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+- `community.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_winrm_enable` | bool | `true` | Enable or disable WinRM service |
+| `windows_manage_winrm_start_mode` | str | `auto` | Service start mode (`auto` or `delayed`) |
+| `windows_manage_winrm_http_block` | bool | `false` | Block HTTP port 5985 in firewall |
+| `windows_manage_winrm_https_enable` | bool | `false` | Enable HTTPS listener with self-signed cert |
+| `windows_manage_winrm_service_config` | dict | *(see defaults)* | WinRM service configuration |
+| `windows_manage_winrm_firewall_profiles` | list(str) | `[domain, private]` | Firewall profiles for rules |
+| `windows_manage_winrm_display_config` | bool | `false` | Display current configuration |
+
+## Example Playbook
+
+```yaml
+- name: Configure WinRM
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_https_enable: true
+        windows_manage_winrm_service_config:
+          AllowUnencrypted: false
+          Auth:
+            Basic: false
+            Kerberos: true
+            Negotiate: true
+            Certificate: false
+            CredSSP: false
+            CbtHardeningLevel: Strict
+```
+
+## Safety
+
+The role refuses to disable WinRM when connected via WinRM or PSRP to prevent self-lockout.
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_winrm/defaults/main.yml
+++ b/roles/windows_manage_winrm/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+# Enable or disable WinRM
+windows_manage_winrm_enable: true
+
+# WinRM service start mode: auto or delayed
+windows_manage_winrm_start_mode: auto
+
+# Block WinRM HTTP port if using HTTPS
+# Kerberos and NTLM encrypt traffic with HTTP
+windows_manage_winrm_http_block: false
+
+# Enable WinRM HTTPS listener with self-signed cert
+windows_manage_winrm_https_enable: false
+
+# WinRM service configuration
+# CBT is None, Relaxed, or Strict
+windows_manage_winrm_service_config:
+  AllowUnencrypted: false
+  Auth:
+    Basic: false
+    Kerberos: true
+    Negotiate: true
+    Certificate: false
+    CredSSP: false
+    CbtHardeningLevel: Relaxed
+  IPv4Filter: '*'
+  IPv6Filter: '*'
+
+# Firewall profiles to apply rules
+windows_manage_winrm_firewall_profiles:
+  - domain
+  - private
+
+# Display current WinRM configuration
+windows_manage_winrm_display_config: false

--- a/roles/windows_manage_winrm/defaults/main.yml
+++ b/roles/windows_manage_winrm/defaults/main.yml
@@ -12,8 +12,13 @@ windows_manage_winrm_http_block: false
 # Enable WinRM HTTPS listener with self-signed cert
 windows_manage_winrm_https_enable: false
 
+# Validity period in years for the self-signed HTTPS certificate
+windows_manage_winrm_https_cert_validity_years: 2
+
 # WinRM service configuration
-# CBT is None, Relaxed, or Strict
+# CbtHardeningLevel: Relaxed permits clients without Channel Binding Token
+# support. Use Strict for stronger NTLM relay protection at the cost of
+# compatibility with older clients.
 windows_manage_winrm_service_config:
   AllowUnencrypted: false
   Auth:
@@ -27,9 +32,11 @@ windows_manage_winrm_service_config:
   IPv6Filter: '*'
 
 # Firewall profiles to apply rules
+# Includes all profiles to ensure complete coverage when disabling
 windows_manage_winrm_firewall_profiles:
   - domain
   - private
+  - public
 
 # Display current WinRM configuration
 windows_manage_winrm_display_config: false

--- a/roles/windows_manage_winrm/meta/argument_specs.yml
+++ b/roles/windows_manage_winrm/meta/argument_specs.yml
@@ -7,6 +7,8 @@ argument_specs:
       - Enable or disable the WinRM service with listener and firewall configuration.
       - Supports HTTPS listener with self-signed certificates.
       - Includes safety check to prevent disabling WinRM over a WinRM connection.
+      - "B(NOTE): The safety check uses C(ansible.builtin.fail) which can be
+        bypassed by wrapping the role call in a C(rescue) block."
     options:
       windows_manage_winrm_enable:
         type: bool
@@ -34,21 +36,32 @@ argument_specs:
           - Enable the WinRM HTTPS listener.
           - Creates a self-signed certificate if no HTTPS listener exists.
         default: false
+      windows_manage_winrm_https_cert_validity_years:
+        type: int
+        description:
+          - Validity period in years for the self-signed HTTPS certificate.
+          - The role does not provide certificate rotation. Plan for renewal
+            before expiry.
+        default: 2
       windows_manage_winrm_service_config:
         type: dict
         description:
-          - WinRM service configuration settings.
-          - Supports Auth sub-keys (Basic, Kerberos, Negotiate, Certificate, CredSSP, CbtHardeningLevel).
-          - Supports AllowUnencrypted, IPv4Filter, IPv6Filter.
+          - WinRM service configuration settings applied to WSMan:\\localhost\\Service.
+          - "Flat keys (C(AllowUnencrypted), C(IPv4Filter), C(IPv6Filter)) must have
+            string values."
+          - "The C(Auth) key accepts a nested dict with sub-keys: C(Basic), C(Kerberos),
+            C(Negotiate), C(Certificate), C(CredSSP), C(CbtHardeningLevel)."
         required: false
       windows_manage_winrm_firewall_profiles:
         type: list
         elements: str
         description:
           - Firewall profiles to apply WinRM rules to.
+          - Valid values are C(domain), C(private), and C(public).
         default:
           - domain
           - private
+          - public
       windows_manage_winrm_display_config:
         type: bool
         description:

--- a/roles/windows_manage_winrm/meta/argument_specs.yml
+++ b/roles/windows_manage_winrm/meta/argument_specs.yml
@@ -1,0 +1,56 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Configure Windows Remote Management (WinRM).
+    description:
+      - Enable or disable the WinRM service with listener and firewall configuration.
+      - Supports HTTPS listener with self-signed certificates.
+      - Includes safety check to prevent disabling WinRM over a WinRM connection.
+    options:
+      windows_manage_winrm_enable:
+        type: bool
+        description:
+          - Enable or disable the WinRM service.
+        default: true
+      windows_manage_winrm_start_mode:
+        type: str
+        description:
+          - WinRM service start mode.
+        default: auto
+        choices:
+          - auto
+          - delayed
+      windows_manage_winrm_http_block:
+        type: bool
+        description:
+          - Block the WinRM HTTP port (5985) in the firewall.
+          - Useful when using HTTPS only.
+          - Kerberos and NTLM encrypt traffic even over HTTP.
+        default: false
+      windows_manage_winrm_https_enable:
+        type: bool
+        description:
+          - Enable the WinRM HTTPS listener.
+          - Creates a self-signed certificate if no HTTPS listener exists.
+        default: false
+      windows_manage_winrm_service_config:
+        type: dict
+        description:
+          - WinRM service configuration settings.
+          - Supports Auth sub-keys (Basic, Kerberos, Negotiate, Certificate, CredSSP, CbtHardeningLevel).
+          - Supports AllowUnencrypted, IPv4Filter, IPv6Filter.
+        required: false
+      windows_manage_winrm_firewall_profiles:
+        type: list
+        elements: str
+        description:
+          - Firewall profiles to apply WinRM rules to.
+        default:
+          - domain
+          - private
+      windows_manage_winrm_display_config:
+        type: bool
+        description:
+          - Display the current WinRM configuration after changes.
+        default: false

--- a/roles/windows_manage_winrm/meta/main.yml
+++ b/roles/windows_manage_winrm/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_winrm
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Configure Windows Remote Management (WinRM) service, listeners, and firewall rules.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - winrm
+    - configuration
+dependencies: []

--- a/roles/windows_manage_winrm/tasks/disable.yml
+++ b/roles/windows_manage_winrm/tasks/disable.yml
@@ -1,0 +1,40 @@
+---
+- name: Fail if trying to disable WinRM using WinRM
+  ansible.builtin.fail:
+    msg: "Refusing to disable WinRM when using WinRM."
+  when: ansible_connection == 'winrm' or
+        ansible_connection == 'psrp'
+
+- name: Check WinRM service
+  ansible.windows.win_service_info:
+    name: WinRM
+  register: windows_manage_winrm_service
+
+- name: Disable WinRM service
+  ansible.windows.win_service:
+    name: WinRM
+    start_mode: disabled
+    state: stopped
+  when: windows_manage_winrm_service.exists
+
+- name: Block firewall WinRM HTTP port
+  community.windows.win_firewall_rule:
+    name: Windows Remote Management (HTTP-In)
+    state: present
+    enabled: true
+    action: block
+    direction: in
+    localport: 5985
+    protocol: tcp
+    profiles: "{{ windows_manage_winrm_firewall_profiles | default(omit, true) }}"
+
+- name: Block firewall WinRM HTTPS port
+  community.windows.win_firewall_rule:
+    name: Windows Remote Management (HTTPS-In)
+    state: present
+    enabled: true
+    action: block
+    direction: in
+    localport: 5986
+    protocol: tcp
+    profiles: "{{ windows_manage_winrm_firewall_profiles | default(omit, true) }}"

--- a/roles/windows_manage_winrm/tasks/display.yml
+++ b/roles/windows_manage_winrm/tasks/display.yml
@@ -9,19 +9,44 @@
     var: windows_manage_winrm_service_info.services[0]
 
 - name: Check WinRM service configuration
-  ansible.windows.win_command: winrm.cmd get winrm/config
+  ansible.windows.win_powershell:
+    script: |
+      $config = @{}
+      Get-ChildItem -Path WSMan:\localhost\Service | ForEach-Object {
+        if ($_.PSIsContainer) {
+          $sub = @{}
+          Get-ChildItem -Path $_.PSPath | ForEach-Object {
+            $sub[$_.Name] = $_.Value
+          }
+          $config[$_.Name] = $sub
+        } else {
+          $config[$_.Name] = $_.Value
+        }
+      }
+      $Ansible.Result = $config
   register: windows_manage_winrm_config_info
   changed_when: false
 
 - name: Display WinRM service configuration
   ansible.builtin.debug:
-    var: windows_manage_winrm_config_info.stdout
+    var: windows_manage_winrm_config_info.result
 
 - name: Check WinRM listener configuration
-  ansible.windows.win_command: winrm.cmd enumerate winrm/config/listener
+  ansible.windows.win_powershell:
+    script: |
+      $listeners = @()
+      Get-WSManInstance winrm/config/Listener -Enumerate | ForEach-Object {
+        $listeners += @{
+          Address   = $_.Address
+          Transport = $_.Transport
+          Port      = $_.Port
+          Enabled   = $_.Enabled
+        }
+      }
+      $Ansible.Result = $listeners
   register: windows_manage_winrm_listener_info
   changed_when: false
 
 - name: Display WinRM listener configuration
   ansible.builtin.debug:
-    var: windows_manage_winrm_listener_info.stdout
+    var: windows_manage_winrm_listener_info.result

--- a/roles/windows_manage_winrm/tasks/display.yml
+++ b/roles/windows_manage_winrm/tasks/display.yml
@@ -1,0 +1,27 @@
+---
+- name: Check WinRM service details
+  ansible.windows.win_service_info:
+    name: WinRM
+  register: windows_manage_winrm_service_info
+
+- name: Display WinRM service details
+  ansible.builtin.debug:
+    var: windows_manage_winrm_service_info.services[0]
+
+- name: Check WinRM service configuration
+  ansible.windows.win_command: winrm.cmd get winrm/config
+  register: windows_manage_winrm_config_info
+  changed_when: false
+
+- name: Display WinRM service configuration
+  ansible.builtin.debug:
+    var: windows_manage_winrm_config_info.stdout
+
+- name: Check WinRM listener configuration
+  ansible.windows.win_command: winrm.cmd enumerate winrm/config/listener
+  register: windows_manage_winrm_listener_info
+  changed_when: false
+
+- name: Display WinRM listener configuration
+  ansible.builtin.debug:
+    var: windows_manage_winrm_listener_info.stdout

--- a/roles/windows_manage_winrm/tasks/enable.yml
+++ b/roles/windows_manage_winrm/tasks/enable.yml
@@ -37,14 +37,17 @@
   check_mode: false
   ansible.windows.win_powershell:
     error_action: stop
+    parameters:
+      CheckMode: "{{ ansible_check_mode }}"
     script: |
+      param($CheckMode)
       $Ansible.Changed = $false
       $friendlyName = 'WinRM over HTTPS'
       $cert = Get-ChildItem -Path Cert:\LocalMachine\My | ? FriendlyName -eq $friendlyName
       $listener = Get-WSManInstance winrm/config/Listener -Enumerate | ? Transport -eq 'HTTPS'
       if (-not $listener) {
         $Ansible.Changed = $true
-        if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+        if ($CheckMode) { Exit 0 }
         if (-not $cert) {
           $cert = New-SelfSignedCertificate -CertStoreLocation Cert:\LocalMachine\My `
                     -DnsName $env:COMPUTERNAME -NotAfter (get-date).AddYears(10) `
@@ -56,7 +59,7 @@
           -ValueSet @{CertificateThumbprint=$cert.Thumbprint;Enabled=$true}
       } elseif ($listener.Enabled -ne $true) {
         $Ansible.Changed = $true
-        if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+        if ($CheckMode) { Exit 0 }
         Set-WSManInstance -ResourceURI winrm/config/Listener `
           -SelectorSet @{Address='*';Transport='HTTPS'} `
           -ValueSet @{Enabled=$true}
@@ -67,28 +70,30 @@
   check_mode: false
   ansible.windows.win_powershell:
     error_action: stop
+    parameters:
+      Key: "{{ item.key }}"
+      Value: "{{ item.value }}"
+      CheckMode: "{{ ansible_check_mode }}"
     script: |
+      param($Key, $Value, $CheckMode)
       $Ansible.Changed = $false
-      $key = '{{ item.key }}'
-      $value = '{{ item.value | to_json if item.value is mapping else item.value }}'
-      if ($value.StartsWith('{')) {
+      if ($Value -is [System.Collections.IDictionary] -or $Value -is [PSCustomObject]) {
         $hash = @{}
-        $value = $value | ConvertFrom-Json
-        $value.PSObject.Properties | ForEach-Object {
+        $Value.PSObject.Properties | ForEach-Object {
           $hash[$_.Name] = $_.Value
         }
-        $value = $hash
+        $Value = $hash
       }
-      if ($key -ne 'Auth') {
-        $current = Get-ChildItem -Path WSMan:\localhost\Service\$key
-        if ($value.ToString().ToLower() -ne $current.Value.ToLower()) {
+      if ($Key -ne 'Auth') {
+        $current = Get-ChildItem -Path WSMan:\localhost\Service\$Key
+        if ($Value.ToString().ToLower() -ne $current.Value.ToLower()) {
           $Ansible.Changed = $true
-          if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
-          Set-Item -Path WSMan:\localhost\Service\$key -Value $value
+          if ($CheckMode) { Exit 0 }
+          Set-Item -Path WSMan:\localhost\Service\$Key -Value $Value
         }
       }
-      if ($key -eq 'Auth') {
-        $value.GetEnumerator() | ForEach-Object {
+      if ($Key -eq 'Auth') {
+        $Value.GetEnumerator() | ForEach-Object {
           $k = $_.key
           $v = $_.value
           $current = Get-ChildItem -Path WSMan:\localhost\Service\Auth\$k
@@ -97,7 +102,7 @@
           }
           if ($v.ToString().ToLower() -ne $current.Value.ToLower()) {
             $Ansible.Changed = $true
-            if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+            if ($CheckMode) { Exit 0 }
             Set-Item -Path WSMan:\localhost\Service\Auth\$k -Value $v
           }
         }

--- a/roles/windows_manage_winrm/tasks/enable.yml
+++ b/roles/windows_manage_winrm/tasks/enable.yml
@@ -1,0 +1,135 @@
+---
+- name: Block firewall WinRM HTTP port
+  community.windows.win_firewall_rule:
+    name: Windows Remote Management (HTTP-In)
+    state: present
+    enabled: true
+    action: block
+    direction: in
+    localport: 5985
+    protocol: tcp
+    profiles: "{{ windows_manage_winrm_firewall_profiles | default(omit, true) }}"
+  when:
+    - ansible_winrm_port | default(0) != 5985
+    - windows_manage_winrm_http_block | bool
+
+- name: Block firewall WinRM HTTPS port
+  community.windows.win_firewall_rule:
+    name: Windows Remote Management (HTTPS-In)
+    state: present
+    enabled: true
+    action: block
+    direction: in
+    localport: 5986
+    protocol: tcp
+    profiles: "{{ windows_manage_winrm_firewall_profiles | default(omit, true) }}"
+  when:
+    - ansible_winrm_port | default(0) != 5986
+    - not windows_manage_winrm_https_enable | bool
+
+- name: Enable WinRM service
+  ansible.windows.win_service:
+    name: WinRM
+    start_mode: "{{ windows_manage_winrm_start_mode }}"
+    state: started
+
+- name: Enable WinRM service HTTPS listener
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $Ansible.Changed = $false
+      $friendlyName = 'WinRM over HTTPS'
+      $cert = Get-ChildItem -Path Cert:\LocalMachine\My | ? FriendlyName -eq $friendlyName
+      $listener = Get-WSManInstance winrm/config/Listener -Enumerate | ? Transport -eq 'HTTPS'
+      if (-not $listener) {
+        $Ansible.Changed = $true
+        if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+        if (-not $cert) {
+          $cert = New-SelfSignedCertificate -CertStoreLocation Cert:\LocalMachine\My `
+                    -DnsName $env:COMPUTERNAME -NotAfter (get-date).AddYears(10) `
+                    -Provider 'Microsoft Software Key Storage Provider'
+          $cert.FriendlyName = $friendlyName
+        }
+        New-WSManInstance -ResourceURI winrm/config/Listener `
+          -SelectorSet @{Address='*';Transport='HTTPS'} `
+          -ValueSet @{CertificateThumbprint=$cert.Thumbprint;Enabled=$true}
+      } elseif ($listener.Enabled -ne $true) {
+        $Ansible.Changed = $true
+        if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+        Set-WSManInstance -ResourceURI winrm/config/Listener `
+          -SelectorSet @{Address='*';Transport='HTTPS'} `
+          -ValueSet @{Enabled=$true}
+      }
+  when: windows_manage_winrm_https_enable | bool
+
+- name: Configure WinRM service
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $Ansible.Changed = $false
+      $key = '{{ item.key }}'
+      $value = '{{ item.value | to_json if item.value is mapping else item.value }}'
+      if ($value.StartsWith('{')) {
+        $hash = @{}
+        $value = $value | ConvertFrom-Json
+        $value.PSObject.Properties | ForEach-Object {
+          $hash[$_.Name] = $_.Value
+        }
+        $value = $hash
+      }
+      if ($key -ne 'Auth') {
+        $current = Get-ChildItem -Path WSMan:\localhost\Service\$key
+        if ($value.ToString().ToLower() -ne $current.Value.ToLower()) {
+          $Ansible.Changed = $true
+          if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+          Set-Item -Path WSMan:\localhost\Service\$key -Value $value
+        }
+      }
+      if ($key -eq 'Auth') {
+        $value.GetEnumerator() | ForEach-Object {
+          $k = $_.key
+          $v = $_.value
+          $current = Get-ChildItem -Path WSMan:\localhost\Service\Auth\$k
+          if ($k -eq 'CbtHardeningLevel') {
+            $v = (Get-Culture).TextInfo.ToTitleCase($v.ToLower())
+          }
+          if ($v.ToString().ToLower() -ne $current.Value.ToLower()) {
+            $Ansible.Changed = $true
+            if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+            Set-Item -Path WSMan:\localhost\Service\Auth\$k -Value $v
+          }
+        }
+      }
+  loop: "{{ windows_manage_winrm_service_config | dict2items }}"
+  loop_control:
+    label: "{{ item.key }}"
+
+- name: Allow firewall WinRM HTTP port
+  community.windows.win_firewall_rule:
+    name: Windows Remote Management (HTTP-In)
+    state: present
+    enabled: true
+    action: allow
+    direction: in
+    localport: 5985
+    protocol: tcp
+    profiles: "{{ windows_manage_winrm_firewall_profiles | default(omit, true) }}"
+  when: not windows_manage_winrm_http_block | bool
+
+- name: Allow firewall WinRM HTTPS port
+  community.windows.win_firewall_rule:
+    name: Windows Remote Management (HTTPS-In)
+    state: present
+    enabled: true
+    action: allow
+    direction: in
+    localport: 5986
+    protocol: tcp
+    profiles: "{{ windows_manage_winrm_firewall_profiles | default(omit, true) }}"
+  when: windows_manage_winrm_https_enable | bool
+
+- name: Display WinRM configuration
+  ansible.builtin.include_tasks: display.yml
+  when: windows_manage_winrm_display_config | bool

--- a/roles/windows_manage_winrm/tasks/enable.yml
+++ b/roles/windows_manage_winrm/tasks/enable.yml
@@ -10,7 +10,7 @@
     protocol: tcp
     profiles: "{{ windows_manage_winrm_firewall_profiles | default(omit, true) }}"
   when:
-    - ansible_winrm_port | default(0) != 5985
+    - ansible_winrm_port | default(0) | int != 5985
     - windows_manage_winrm_http_block | bool
 
 - name: Block firewall WinRM HTTPS port
@@ -24,7 +24,7 @@
     protocol: tcp
     profiles: "{{ windows_manage_winrm_firewall_profiles | default(omit, true) }}"
   when:
-    - ansible_winrm_port | default(0) != 5986
+    - ansible_winrm_port | default(0) | int != 5986
     - not windows_manage_winrm_https_enable | bool
 
 - name: Enable WinRM service
@@ -34,23 +34,24 @@
     state: started
 
 - name: Enable WinRM service HTTPS listener
-  check_mode: false
   ansible.windows.win_powershell:
     error_action: stop
-    parameters:
-      CheckMode: "{{ ansible_check_mode }}"
     script: |
-      param($CheckMode)
       $Ansible.Changed = $false
       $friendlyName = 'WinRM over HTTPS'
       $cert = Get-ChildItem -Path Cert:\LocalMachine\My | ? FriendlyName -eq $friendlyName
       $listener = Get-WSManInstance winrm/config/Listener -Enumerate | ? Transport -eq 'HTTPS'
       if (-not $listener) {
         $Ansible.Changed = $true
-        if ($CheckMode) { Exit 0 }
+        if ($Ansible.CheckMode) { return }
         if (-not $cert) {
+          $dnsNames = @($env:COMPUTERNAME)
+          $domain = (Get-WmiObject Win32_ComputerSystem).Domain
+          if ($domain -and $domain -ne 'WORKGROUP') {
+            $dnsNames += "$($env:COMPUTERNAME).$domain"
+          }
           $cert = New-SelfSignedCertificate -CertStoreLocation Cert:\LocalMachine\My `
-                    -DnsName $env:COMPUTERNAME -NotAfter (get-date).AddYears(10) `
+                    -DnsName $dnsNames -NotAfter (get-date).AddYears(10) `
                     -Provider 'Microsoft Software Key Storage Provider'
           $cert.FriendlyName = $friendlyName
         }
@@ -59,7 +60,7 @@
           -ValueSet @{CertificateThumbprint=$cert.Thumbprint;Enabled=$true}
       } elseif ($listener.Enabled -ne $true) {
         $Ansible.Changed = $true
-        if ($CheckMode) { Exit 0 }
+        if ($Ansible.CheckMode) { return }
         Set-WSManInstance -ResourceURI winrm/config/Listener `
           -SelectorSet @{Address='*';Transport='HTTPS'} `
           -ValueSet @{Enabled=$true}
@@ -67,15 +68,13 @@
   when: windows_manage_winrm_https_enable | bool
 
 - name: Configure WinRM service
-  check_mode: false
   ansible.windows.win_powershell:
     error_action: stop
     parameters:
       Key: "{{ item.key }}"
       Value: "{{ item.value }}"
-      CheckMode: "{{ ansible_check_mode }}"
     script: |
-      param($Key, $Value, $CheckMode)
+      param($Key, $Value)
       $Ansible.Changed = $false
       if ($Value -is [System.Collections.IDictionary] -or $Value -is [PSCustomObject]) {
         $hash = @{}
@@ -88,8 +87,9 @@
         $current = Get-ChildItem -Path WSMan:\localhost\Service\$Key
         if ($Value.ToString().ToLower() -ne $current.Value.ToLower()) {
           $Ansible.Changed = $true
-          if ($CheckMode) { Exit 0 }
-          Set-Item -Path WSMan:\localhost\Service\$Key -Value $Value
+          if (-not $Ansible.CheckMode) {
+            Set-Item -Path WSMan:\localhost\Service\$Key -Value $Value
+          }
         }
       }
       if ($Key -eq 'Auth') {
@@ -102,8 +102,9 @@
           }
           if ($v.ToString().ToLower() -ne $current.Value.ToLower()) {
             $Ansible.Changed = $true
-            if ($CheckMode) { Exit 0 }
-            Set-Item -Path WSMan:\localhost\Service\Auth\$k -Value $v
+            if (-not $Ansible.CheckMode) {
+              Set-Item -Path WSMan:\localhost\Service\Auth\$k -Value $v
+            }
           }
         }
       }

--- a/roles/windows_manage_winrm/tasks/enable.yml
+++ b/roles/windows_manage_winrm/tasks/enable.yml
@@ -11,6 +11,7 @@
     profiles: "{{ windows_manage_winrm_firewall_profiles | default(omit, true) }}"
   when:
     - ansible_winrm_port | default(0) | int != 5985
+    - ansible_psrp_port | default(0) | int != 5985
     - windows_manage_winrm_http_block | bool
 
 - name: Block firewall WinRM HTTPS port
@@ -25,6 +26,7 @@
     profiles: "{{ windows_manage_winrm_firewall_profiles | default(omit, true) }}"
   when:
     - ansible_winrm_port | default(0) | int != 5986
+    - ansible_psrp_port | default(0) | int != 5986
     - not windows_manage_winrm_https_enable | bool
 
 - name: Enable WinRM service
@@ -36,7 +38,10 @@
 - name: Enable WinRM service HTTPS listener
   ansible.windows.win_powershell:
     error_action: stop
+    parameters:
+      CertValidityYears: "{{ windows_manage_winrm_https_cert_validity_years }}"
     script: |
+      param([int]$CertValidityYears)
       $Ansible.Changed = $false
       $friendlyName = 'WinRM over HTTPS'
       $cert = Get-ChildItem -Path Cert:\LocalMachine\My | ? FriendlyName -eq $friendlyName
@@ -46,12 +51,12 @@
         if ($Ansible.CheckMode) { return }
         if (-not $cert) {
           $dnsNames = @($env:COMPUTERNAME)
-          $domain = (Get-WmiObject Win32_ComputerSystem).Domain
+          $domain = (Get-CimInstance Win32_ComputerSystem).Domain
           if ($domain -and $domain -ne 'WORKGROUP') {
             $dnsNames += "$($env:COMPUTERNAME).$domain"
           }
           $cert = New-SelfSignedCertificate -CertStoreLocation Cert:\LocalMachine\My `
-                    -DnsName $dnsNames -NotAfter (get-date).AddYears(10) `
+                    -DnsName $dnsNames -NotAfter (get-date).AddYears($CertValidityYears) `
                     -Provider 'Microsoft Software Key Storage Provider'
           $cert.FriendlyName = $friendlyName
         }

--- a/roles/windows_manage_winrm/tasks/main.yml
+++ b/roles/windows_manage_winrm/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Disable WinRM
+  ansible.builtin.include_tasks: disable.yml
+  when: not windows_manage_winrm_enable | bool
+
+- name: Enable WinRM
+  ansible.builtin.include_tasks: enable.yml
+  when: windows_manage_winrm_enable | bool

--- a/tests/integration/targets/windows_ops_test_windows_manage_winrm/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_winrm/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_winrm/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_winrm/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Test uses display_config toggle and verifies service state
+# Does not test disable path (would break WinRM connection)

--- a/tests/integration/targets/windows_ops_test_windows_manage_winrm/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_winrm/tasks/main.yml
@@ -40,9 +40,11 @@
             msg: "WinRM disable should have been refused over WinRM connection"
 
       rescue:
-        - name: Confirm disable was refused
-          ansible.builtin.debug:
-            msg: "WinRM disable was correctly refused over WinRM connection"
+        - name: Assert disable was refused for the right reason
+          ansible.builtin.assert:
+            that:
+              - ansible_failed_result.msg is search('Refusing to disable WinRM')
+            fail_msg: "Role failed for unexpected reason: {{ ansible_failed_result.msg }}"
 
   always:
     - name: Ensure WinRM is still enabled

--- a/tests/integration/targets/windows_ops_test_windows_manage_winrm/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_winrm/tasks/main.yml
@@ -30,6 +30,7 @@
           }
           $Ansible.Result = $result
       register: windows_manage_winrm_auth_before
+      check_mode: false
       changed_when: false
 
     - name: Run role again to verify idempotency
@@ -53,6 +54,7 @@
           }
           $Ansible.Result = $result
       register: windows_manage_winrm_auth_after
+      check_mode: false
       changed_when: false
 
     - name: Assert state unchanged after idempotent re-run
@@ -96,6 +98,7 @@
             enabled = if ($listener) { $listener.Enabled } else { $null }
           }
       register: windows_manage_winrm_verify_https
+      check_mode: false
       changed_when: false
 
     - name: Assert HTTPS listener is configured
@@ -119,6 +122,7 @@
             $Ansible.Result = @{ exists = $false }
           }
       register: windows_manage_winrm_verify_https_fw
+      check_mode: false
       changed_when: false
 
     - name: Assert HTTPS firewall rule allows traffic
@@ -128,18 +132,55 @@
           - windows_manage_winrm_verify_https_fw.result.action == 'Allow'
         fail_msg: "HTTPS firewall rule is not set to allow"
 
-    # -- service_config test --
-    - name: Capture current auth settings
+    # -- http_block safety guard test --
+    - name: Capture HTTP firewall rule before http_block test
       ansible.windows.win_powershell:
         script: |
-          $result = @{}
-          Get-ChildItem -Path WSMan:\localhost\Service\Auth | ForEach-Object {
-            $result[$_.Name] = $_.Value
+          $rule = Get-NetFirewallRule -DisplayName 'Windows Remote Management (HTTP-In)' -ErrorAction SilentlyContinue
+          $Ansible.Result = @{
+            action = if ($rule) { $rule.Action.ToString() } else { 'NotFound' }
           }
-          $Ansible.Result = $result
-      register: windows_manage_winrm_original_auth
+      register: windows_manage_winrm_http_fw_before
+      check_mode: false
       changed_when: false
 
+    - name: Configure WinRM with http_block enabled (guard should prevent block)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_http_block: true
+        windows_manage_winrm_display_config: false
+
+    - name: Verify HTTP firewall rule was NOT blocked (safety guard)
+      ansible.windows.win_powershell:
+        script: |
+          $rule = Get-NetFirewallRule -DisplayName 'Windows Remote Management (HTTP-In)' -ErrorAction SilentlyContinue
+          $Ansible.Result = @{
+            action = if ($rule) { $rule.Action.ToString() } else { 'NotFound' }
+          }
+      register: windows_manage_winrm_http_fw_after
+      check_mode: false
+      changed_when: false
+
+    - name: Assert HTTP port not blocked while connected on it
+      ansible.builtin.assert:
+        that:
+          - windows_manage_winrm_http_fw_after.result.action == windows_manage_winrm_http_fw_before.result.action
+        fail_msg: >-
+          Safety guard failed - HTTP firewall rule changed from
+          {{ windows_manage_winrm_http_fw_before.result.action }} to
+          {{ windows_manage_winrm_http_fw_after.result.action }}
+
+    - name: Restore http_block to default
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_http_block: false
+        windows_manage_winrm_display_config: false
+
+    # -- service_config test --
     - name: Configure WinRM with custom service_config
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_winrm
@@ -164,6 +205,7 @@
           $basic = (Get-ChildItem -Path WSMan:\localhost\Service\Auth\Basic).Value
           $Ansible.Result = @{ basic = $basic }
       register: windows_manage_winrm_verify_basic
+      check_mode: false
       changed_when: false
 
     - name: Assert Basic auth is enabled
@@ -172,7 +214,7 @@
           - windows_manage_winrm_verify_basic.result.basic == 'true'
         fail_msg: "Basic auth was not enabled by service_config"
 
-    - name: Restore original auth settings
+    - name: Restore default auth settings
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_winrm
       vars:
@@ -189,6 +231,77 @@
             CbtHardeningLevel: Relaxed
           IPv4Filter: '*'
           IPv6Filter: '*'
+
+    # -- start_mode: delayed test --
+    - name: Configure WinRM with delayed start
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_start_mode: delayed
+        windows_manage_winrm_display_config: false
+
+    - name: Verify WinRM service start mode is delayed
+      ansible.windows.win_service_info:
+        name: WinRM
+      register: windows_manage_winrm_verify_delayed
+
+    - name: Assert start mode is delayed
+      ansible.builtin.assert:
+        that:
+          - windows_manage_winrm_verify_delayed.services[0].start_mode == 'delayed'
+        fail_msg: "WinRM start_mode was not set to delayed"
+
+    - name: Restore start mode to auto
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_start_mode: auto
+        windows_manage_winrm_display_config: false
+
+    # -- Non-default firewall profiles test --
+    - name: Configure WinRM with domain-only firewall profiles
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_firewall_profiles:
+          - domain
+        windows_manage_winrm_display_config: false
+
+    - name: Verify HTTP firewall rule profiles
+      ansible.windows.win_powershell:
+        script: |
+          $rule = Get-NetFirewallRule -DisplayName 'Windows Remote Management (HTTP-In)' -ErrorAction SilentlyContinue
+          if ($rule) {
+            $profiles = $rule.Profile.ToString()
+            $Ansible.Result = @{ profiles = $profiles }
+          } else {
+            $Ansible.Result = @{ profiles = 'NotFound' }
+          }
+      register: windows_manage_winrm_verify_profiles
+      check_mode: false
+      changed_when: false
+
+    - name: Assert firewall rule has domain profile
+      ansible.builtin.assert:
+        that:
+          - "'Domain' in windows_manage_winrm_verify_profiles.result.profiles"
+        fail_msg: >-
+          Firewall profiles not set correctly:
+          {{ windows_manage_winrm_verify_profiles.result.profiles }}
+
+    - name: Restore default firewall profiles
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_firewall_profiles:
+          - domain
+          - private
+          - public
+        windows_manage_winrm_display_config: false
 
     # -- Disable safety check --
     - name: Test disable safety check
@@ -222,16 +335,16 @@
             Remove-WSManInstance -ResourceURI winrm/config/Listener `
               -SelectorSet @{Address='*';Transport='HTTPS'}
           }
+      check_mode: false
 
-    - name: Restore HTTPS listener if it existed before
-      ansible.windows.win_powershell:
-        script: |
-          $Ansible.Changed = $false
-      when: not (windows_manage_winrm_pre_https_cleanup.changed | default(false))
-
-    - name: Ensure WinRM is still enabled
+    - name: Ensure WinRM is still enabled with defaults
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_winrm
       vars:
         windows_manage_winrm_enable: true
+        windows_manage_winrm_start_mode: auto
+        windows_manage_winrm_firewall_profiles:
+          - domain
+          - private
+          - public
         windows_manage_winrm_display_config: false

--- a/tests/integration/targets/windows_ops_test_windows_manage_winrm/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_winrm/tasks/main.yml
@@ -20,6 +20,18 @@
           - windows_manage_winrm_verify_service.services[0].start_mode == 'auto'
         fail_msg: "WinRM service is not in expected state"
 
+    # -- Idempotency test --
+    - name: Capture WinRM auth config before idempotency re-run
+      ansible.windows.win_powershell:
+        script: |
+          $result = @{}
+          Get-ChildItem -Path WSMan:\localhost\Service\Auth | ForEach-Object {
+            $result[$_.Name] = $_.Value
+          }
+          $Ansible.Result = $result
+      register: windows_manage_winrm_auth_before
+      changed_when: false
+
     - name: Run role again to verify idempotency
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_winrm
@@ -27,6 +39,158 @@
         windows_manage_winrm_enable: true
         windows_manage_winrm_display_config: false
 
+    - name: Verify WinRM service still running after idempotent re-run
+      ansible.windows.win_service_info:
+        name: WinRM
+      register: windows_manage_winrm_verify_idempotent
+
+    - name: Capture WinRM auth config after idempotency re-run
+      ansible.windows.win_powershell:
+        script: |
+          $result = @{}
+          Get-ChildItem -Path WSMan:\localhost\Service\Auth | ForEach-Object {
+            $result[$_.Name] = $_.Value
+          }
+          $Ansible.Result = $result
+      register: windows_manage_winrm_auth_after
+      changed_when: false
+
+    - name: Assert state unchanged after idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_winrm_verify_idempotent.services[0].state == 'started'
+          - windows_manage_winrm_verify_idempotent.services[0].start_mode == 'auto'
+          - windows_manage_winrm_auth_before.result == windows_manage_winrm_auth_after.result
+        fail_msg: "Role is not idempotent - service or auth config changed on re-run"
+
+    # -- HTTPS listener test --
+    - name: Remove existing HTTPS listener if present
+      ansible.windows.win_powershell:
+        script: |
+          $Ansible.Changed = $false
+          $listener = Get-WSManInstance winrm/config/Listener -Enumerate |
+            Where-Object { $_.Transport -eq 'HTTPS' }
+          if ($listener) {
+            $Ansible.Changed = $true
+            Remove-WSManInstance -ResourceURI winrm/config/Listener `
+              -SelectorSet @{Address='*';Transport='HTTPS'}
+          }
+      register: windows_manage_winrm_pre_https_cleanup
+
+    - name: Configure WinRM with HTTPS enabled
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_https_enable: true
+        windows_manage_winrm_display_config: false
+
+    - name: Verify HTTPS listener exists
+      ansible.windows.win_powershell:
+        script: |
+          $listener = Get-WSManInstance winrm/config/Listener -Enumerate |
+            Where-Object { $_.Transport -eq 'HTTPS' }
+          $Ansible.Result = @{
+            exists = [bool]$listener
+            port = if ($listener) { $listener.Port } else { $null }
+            enabled = if ($listener) { $listener.Enabled } else { $null }
+          }
+      register: windows_manage_winrm_verify_https
+      changed_when: false
+
+    - name: Assert HTTPS listener is configured
+      ansible.builtin.assert:
+        that:
+          - windows_manage_winrm_verify_https.result.exists
+          - windows_manage_winrm_verify_https.result.port == '5986'
+        fail_msg: "HTTPS listener was not created"
+
+    - name: Verify HTTPS firewall rule is allowed
+      ansible.windows.win_powershell:
+        script: |
+          $rule = Get-NetFirewallRule -DisplayName 'Windows Remote Management (HTTPS-In)' -ErrorAction SilentlyContinue
+          if ($rule) {
+            $Ansible.Result = @{
+              exists = $true
+              action = $rule.Action.ToString()
+              enabled = $rule.Enabled.ToString()
+            }
+          } else {
+            $Ansible.Result = @{ exists = $false }
+          }
+      register: windows_manage_winrm_verify_https_fw
+      changed_when: false
+
+    - name: Assert HTTPS firewall rule allows traffic
+      ansible.builtin.assert:
+        that:
+          - windows_manage_winrm_verify_https_fw.result.exists
+          - windows_manage_winrm_verify_https_fw.result.action == 'Allow'
+        fail_msg: "HTTPS firewall rule is not set to allow"
+
+    # -- service_config test --
+    - name: Capture current auth settings
+      ansible.windows.win_powershell:
+        script: |
+          $result = @{}
+          Get-ChildItem -Path WSMan:\localhost\Service\Auth | ForEach-Object {
+            $result[$_.Name] = $_.Value
+          }
+          $Ansible.Result = $result
+      register: windows_manage_winrm_original_auth
+      changed_when: false
+
+    - name: Configure WinRM with custom service_config
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_display_config: false
+        windows_manage_winrm_service_config:
+          AllowUnencrypted: false
+          Auth:
+            Basic: true
+            Kerberos: true
+            Negotiate: true
+            Certificate: false
+            CredSSP: false
+            CbtHardeningLevel: Relaxed
+          IPv4Filter: '*'
+          IPv6Filter: '*'
+
+    - name: Verify Basic auth was enabled
+      ansible.windows.win_powershell:
+        script: |
+          $basic = (Get-ChildItem -Path WSMan:\localhost\Service\Auth\Basic).Value
+          $Ansible.Result = @{ basic = $basic }
+      register: windows_manage_winrm_verify_basic
+      changed_when: false
+
+    - name: Assert Basic auth is enabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_winrm_verify_basic.result.basic == 'true'
+        fail_msg: "Basic auth was not enabled by service_config"
+
+    - name: Restore original auth settings
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_display_config: false
+        windows_manage_winrm_service_config:
+          AllowUnencrypted: false
+          Auth:
+            Basic: false
+            Kerberos: true
+            Negotiate: true
+            Certificate: false
+            CredSSP: false
+            CbtHardeningLevel: Relaxed
+          IPv4Filter: '*'
+          IPv6Filter: '*'
+
+    # -- Disable safety check --
     - name: Test disable safety check
       block:
         - name: Attempt to disable WinRM (should fail)
@@ -47,6 +211,24 @@
             fail_msg: "Role failed for unexpected reason: {{ ansible_failed_result.msg }}"
 
   always:
+    - name: Clean up HTTPS listener
+      ansible.windows.win_powershell:
+        script: |
+          $Ansible.Changed = $false
+          $listener = Get-WSManInstance winrm/config/Listener -Enumerate |
+            Where-Object { $_.Transport -eq 'HTTPS' }
+          if ($listener) {
+            $Ansible.Changed = $true
+            Remove-WSManInstance -ResourceURI winrm/config/Listener `
+              -SelectorSet @{Address='*';Transport='HTTPS'}
+          }
+
+    - name: Restore HTTPS listener if it existed before
+      ansible.windows.win_powershell:
+        script: |
+          $Ansible.Changed = $false
+      when: not (windows_manage_winrm_pre_https_cleanup.changed | default(false))
+
     - name: Ensure WinRM is still enabled
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_winrm

--- a/tests/integration/targets/windows_ops_test_windows_manage_winrm/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_winrm/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+- name: Test WinRM configuration
+  block:
+    - name: Configure WinRM with display enabled
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_display_config: true
+
+    - name: Verify WinRM service is running
+      ansible.windows.win_service_info:
+        name: WinRM
+      register: windows_manage_winrm_verify_service
+
+    - name: Assert WinRM service is started
+      ansible.builtin.assert:
+        that:
+          - windows_manage_winrm_verify_service.services[0].state == 'started'
+          - windows_manage_winrm_verify_service.services[0].start_mode == 'auto'
+        fail_msg: "WinRM service is not in expected state"
+
+    - name: Run role again to verify idempotency
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_display_config: false
+
+    - name: Test disable safety check
+      block:
+        - name: Attempt to disable WinRM (should fail)
+          ansible.builtin.include_role:
+            name: infra.windows_ops.windows_manage_winrm
+          vars:
+            windows_manage_winrm_enable: false
+
+        - name: Fail if disable was not refused
+          ansible.builtin.fail:
+            msg: "WinRM disable should have been refused over WinRM connection"
+
+      rescue:
+        - name: Confirm disable was refused
+          ansible.builtin.debug:
+            msg: "WinRM disable was correctly refused over WinRM connection"
+
+  always:
+    - name: Ensure WinRM is still enabled
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_winrm
+      vars:
+        windows_manage_winrm_enable: true
+        windows_manage_winrm_display_config: false


### PR DESCRIPTION
##### SUMMARY
Add new `windows_manage_winrm` role for configuring Windows Remote Management.

- Enable/disable WinRM service with start mode configuration
- HTTPS listener support with self-signed certificate creation
- WinRM service configuration (auth methods, encryption, IP filters)
- Firewall rule management for HTTP (5985) and HTTPS (5986) ports
- Safety check: refuses to disable WinRM over a WinRM/PSRP connection
- Display current WinRM/listener configuration via `winrm.cmd`
- Replaced `win_powershell` with `win_command` for display tasks (CLI commands)
- Includes integration tests with enable/idempotency/safety-check verification
- Includes AAP pattern (setup, playbook, survey, execution environment)
- Includes changelog fragment

Part of ACA-2792 Batch 2 (Network and Remote Access).

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
roles/windows_manage_winrm