### PR TITLE
feat(windows_manage_firewall): add role for managing Windows firewall profiles and rules

### DIFF
--- a/changelogs/fragments/add-windows-manage-firewall.yml
+++ b/changelogs/fragments/add-windows-manage-firewall.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "windows_manage_firewall - new role for managing Windows firewall profiles and rules with enable/disable support
+    and skip-on-conflict safety logic."

--- a/changelogs/fragments/add-windows-manage-firewall.yml
+++ b/changelogs/fragments/add-windows-manage-firewall.yml
@@ -1,4 +1,5 @@
 ---
 minor_changes:
   - "windows_manage_firewall - new role for managing Windows firewall profiles and rules with enable/disable support
-    and skip-on-conflict safety logic."
+    and skip-on-conflict safety logic
+    (https://github.com/redhat-cop/infra.windows_ops/pull/76)."

--- a/extensions/patterns/manage_firewall/README.md
+++ b/extensions/patterns/manage_firewall/README.md
@@ -1,0 +1,53 @@
+# Windows Firewall Pattern
+
+## Description
+
+This pattern is designed to facilitate the automated management of Windows firewall profiles and rules using Ansible. It provides a streamlined way to seed the necessary resources to enable or disable firewall profiles and individual firewall rules.
+
+## What This Pattern Covers
+
+This pattern includes the following key components:
+
+### Project Templates
+
+- **Manage Firewall Project Template**: Defined within the `setup.yaml` playbook, this template helps organize and manage all necessary components for the manage firewall pattern. It ensures that relevant files, roles, and configurations are logically arranged, making it easier to maintain and execute automation tasks.
+
+### Playbooks
+
+- **Playbooks**: Located in the playbooks directory, these scripts are specifically designed to execute the `windows_manage_firewall` role with the appropriate variables.
+
+### Surveys
+
+- **Manage Firewall Surveys**: Defined within the `manage_firewall.yaml` file, manage firewall surveys provide a dynamic interaction mechanism for users to specify parameters for the firewall management jobs. These surveys enable users to:
+  - Choose the firewall profile (domain, private, public)
+  - Choose the profile state (enable, disable)
+
+## Resources Created by This Pattern
+
+1. **Project Templates**
+    - Ensure that all relevant files, roles, and configurations are logically arranged, facilitating easier maintenance and execution of automation tasks.
+
+2. **Job Templates**
+    - Outline the necessary parameters and configurations to perform management of firewall profiles and rules using the provided playbooks.
+
+## How to Use
+
+1. **Use Seed Red Hat pattern Job**
+    - Ensure the custom EE is correctly built and available in your Ansible Automation Platform. Execute the "Seed Red Hat pattern" job within the Ansible Automation Platform, and select the "Windows" category to load this pattern.
+
+2. **Use the Job Templates**
+    - In the `Windows Operations / Manage Firewall` execute the required job templates to manage firewall configurations. Monitor the job execution and verify that the firewall is in the correct state.
+
+## Contribution
+
+Contributions to this project are welcome. Please fork the repository, make your changes, and submit a pull request.
+
+## License
+
+GNU General Public License v3.0 or later.
+
+See [LICENSE](https://www.gnu.org/licenses/gpl-3.0.txt) to see the full text. This project is licensed under the MIT License. See the [LICENSE](https://github.com/redhat-cop/infra.windows_ops/blob/main/LICENSE) file for details.
+
+---
+
+For any issues or questions, please open an issue on the [GitHub issue tracker](https://github.com/redhat-cop/infra.windows_ops/issues).

--- a/extensions/patterns/manage_firewall/README.md
+++ b/extensions/patterns/manage_firewall/README.md
@@ -46,7 +46,7 @@ Contributions to this project are welcome. Please fork the repository, make your
 
 GNU General Public License v3.0 or later.
 
-See [LICENSE](https://www.gnu.org/licenses/gpl-3.0.txt) to see the full text. This project is licensed under the MIT License. See the [LICENSE](https://github.com/redhat-cop/infra.windows_ops/blob/main/LICENSE) file for details.
+See [LICENSE](https://www.gnu.org/licenses/gpl-3.0.txt) to see the full text. See the [LICENSE](https://github.com/redhat-cop/infra.windows_ops/blob/main/LICENSE) file for details.
 
 ---
 

--- a/extensions/patterns/manage_firewall/exec_env/README.md
+++ b/extensions/patterns/manage_firewall/exec_env/README.md
@@ -1,0 +1,7 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_firewall/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_firewall/exec_env/execution-environment.yml
@@ -1,0 +1,13 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner
+  system:
+    - podman

--- a/extensions/patterns/manage_firewall/exec_env/requirements.yml
+++ b/extensions/patterns/manage_firewall/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_firewall/playbooks/run_manage_firewall.yml
+++ b/extensions/patterns/manage_firewall/playbooks/run_manage_firewall.yml
@@ -6,4 +6,11 @@
     - name: Manage Windows Firewall
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_firewall
+      vars:
+        windows_manage_firewall_profiles_enable: >-
+          {{ [{'profiles': [firewall_profile]}]
+             if firewall_profile_state | default('') == 'enable' else [] }}
+        windows_manage_firewall_profiles_disable: >-
+          {{ [{'profiles': [firewall_profile]}]
+             if firewall_profile_state | default('') == 'disable' else [] }}
 ...

--- a/extensions/patterns/manage_firewall/playbooks/run_manage_firewall.yml
+++ b/extensions/patterns/manage_firewall/playbooks/run_manage_firewall.yml
@@ -1,0 +1,9 @@
+---
+- name: Manage Windows Firewall
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Manage Windows Firewall
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_firewall
+...

--- a/extensions/patterns/manage_firewall/setup.yml
+++ b/extensions/patterns/manage_firewall/setup.yml
@@ -1,0 +1,55 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_firewall_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_firewall
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of Windows firewall
+      profiles and rules. It organizes all necessary resources, including playbooks, job templates,
+      and surveys, to ensure seamless management of firewall configurations.
+    organization: Default
+    scm_branch: main
+    scm_clean: 'no'
+    scm_delete_on_update: 'no'
+    scm_type: git
+    scm_update_on_launch: 'yes'
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Firewall
+    description: >
+      This job template manages Windows firewall profiles and rules, enabling or disabling
+      them as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_firewall_pattern
+      - run_manage_firewall
+    playbook: "extensions/patterns/manage_firewall/playbooks/run_manage_firewall.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_firewall.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_firewall/template_surveys/manage_firewall.yml
+++ b/extensions/patterns/manage_firewall/template_surveys/manage_firewall.yml
@@ -1,0 +1,22 @@
+---
+name: "Manage Firewall Configuration Survey"
+description: "Survey to configure Windows firewall profiles and rules"
+spec:
+  - question_name: "Firewall Profile"
+    question_description: "Select the firewall profile to manage"
+    required: true
+    variable: "firewall_profile"
+    type: "multiplechoice"
+    choices:
+      - "domain"
+      - "private"
+      - "public"
+
+  - question_name: "Profile State"
+    question_description: "Enable or disable the selected firewall profile"
+    required: true
+    variable: "firewall_profile_state"
+    type: "multiplechoice"
+    choices:
+      - "enable"
+      - "disable"

--- a/roles/windows_manage_firewall/README.md
+++ b/roles/windows_manage_firewall/README.md
@@ -1,0 +1,60 @@
+# windows_manage_firewall
+
+Manage Windows firewall profiles and rules.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+- `community.windows` collection
+
+## Role Variables
+
+| Variable | Description | Type | Default |
+|----------|-------------|------|---------|
+| **windows_manage_firewall_profiles_disable** | Firewall profiles to disable | list(dict) | `[]` |
+| **windows_manage_firewall_profiles_enable** | Firewall profiles to enable | list(dict) | `[]` |
+| **windows_manage_firewall_rules_disable** | Firewall rules to disable | list(dict) | `[]` |
+| **windows_manage_firewall_rules_enable** | Firewall rules to enable | list(dict) | `[]` |
+
+Each profile item should have a `profiles` key with a list of profile names (`domain`, `private`, `public`). Optional keys `inbound_action` and `outbound_action` set default actions.
+
+Each rule item uses `community.windows.win_firewall_rule` parameters (`name`, `localport`, `protocol`, `action`, `direction`, `profiles`, etc.).
+
+Items present in both disable and enable lists are skipped from the disable operation.
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+- hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_firewall
+      vars:
+        windows_manage_firewall_profiles_enable:
+          - profiles:
+              - domain
+              - private
+              - public
+        windows_manage_firewall_rules_enable:
+          - name: OpenSSH SSH Server (sshd)
+            localport: 22
+            action: allow
+            direction: in
+            protocol: tcp
+            profiles:
+              - domain
+              - private
+              - public
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+Red Hat Ansible Content Team

--- a/roles/windows_manage_firewall/defaults/main.yml
+++ b/roles/windows_manage_firewall/defaults/main.yml
@@ -1,0 +1,37 @@
+---
+# List of firewall profiles to disable
+# Each item should have a 'profiles' key with a list of profile names
+windows_manage_firewall_profiles_disable: []
+#  - profiles:
+#      - trusted
+
+# List of firewall profiles to enable
+# Each item should have a 'profiles' key with a list of profile names
+# Optional keys: inbound_action, outbound_action
+windows_manage_firewall_profiles_enable: []
+#  - profiles:
+#      - domain
+#      - private
+#      - public
+
+# List of firewall rules to disable
+# Each item uses community.windows.win_firewall_rule parameters
+windows_manage_firewall_rules_disable: []
+#  - name: Remote Desktop - User Mode (TCP-In)
+#    localport: 3389
+#    action: allow
+#    direction: in
+#    protocol: tcp
+
+# List of firewall rules to enable
+# Each item uses community.windows.win_firewall_rule parameters
+windows_manage_firewall_rules_enable: []
+#  - name: OpenSSH SSH Server (sshd)
+#    localport: 22
+#    action: allow
+#    direction: in
+#    protocol: tcp
+#    profiles:
+#      - domain
+#      - private
+#      - public

--- a/roles/windows_manage_firewall/meta/argument_specs.yml
+++ b/roles/windows_manage_firewall/meta/argument_specs.yml
@@ -1,0 +1,41 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Manage Windows firewall profiles and rules.
+    description:
+      - Enable or disable Windows firewall profiles and individual firewall rules.
+      - Profiles control the overall firewall state per network category.
+      - Rules control individual port, protocol, and application access.
+    options:
+      windows_manage_firewall_profiles_disable:
+        type: list
+        elements: dict
+        description:
+          - List of firewall profiles to disable.
+          - Each item should include a C(profiles) key with a list of profile names.
+          - Items also present in C(windows_manage_firewall_profiles_enable) are skipped.
+        default: []
+      windows_manage_firewall_profiles_enable:
+        type: list
+        elements: dict
+        description:
+          - List of firewall profiles to enable.
+          - Each item should include a C(profiles) key with a list of profile names.
+          - Optional keys C(inbound_action) and C(outbound_action) control default actions.
+        default: []
+      windows_manage_firewall_rules_disable:
+        type: list
+        elements: dict
+        description:
+          - List of firewall rules to disable.
+          - Each item uses C(community.windows.win_firewall_rule) parameters.
+          - Items also present in C(windows_manage_firewall_rules_enable) are skipped.
+        default: []
+      windows_manage_firewall_rules_enable:
+        type: list
+        elements: dict
+        description:
+          - List of firewall rules to enable.
+          - Each item uses C(community.windows.win_firewall_rule) parameters.
+        default: []

--- a/roles/windows_manage_firewall/meta/main.yml
+++ b/roles/windows_manage_firewall/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_firewall
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Manage Windows firewall profiles and rules.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - firewall
+    - security
+dependencies: []

--- a/roles/windows_manage_firewall/tasks/main.yml
+++ b/roles/windows_manage_firewall/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Disable firewall rules
   community.windows.win_firewall_rule:
-    state: "{{ item.state | default('present') }}"
+    state: present
     name: "{{ item.name | default(omit) }}"
     enabled: false
     description: "{{ item.description | default(omit) }}"
@@ -41,7 +41,7 @@
   loop: "{{ windows_manage_firewall_rules_disable | select }}"
   loop_control:
     label: "{{ item.name | default(item) }}"
-  when: item not in windows_manage_firewall_rules_enable
+  when: item not in windows_manage_firewall_rules_enable | select
 
 - name: Enable firewall rules
   community.windows.win_firewall_rule:

--- a/roles/windows_manage_firewall/tasks/main.yml
+++ b/roles/windows_manage_firewall/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: Disable firewall profiles
+  ansible.windows.win_firewall:
+    state: disabled
+    profiles: "{{ item.profiles | default(omit) }}"
+    inbound_action: "{{ item.inbound_action | default(omit) }}"
+    outbound_action: "{{ item.outbound_action | default(omit) }}"
+  loop: "{{ windows_manage_firewall_profiles_disable | select }}"
+  loop_control:
+    label: "{{ item.profiles | default(item) }}"
+  when: item not in windows_manage_firewall_profiles_enable | select
+
+- name: Enable firewall profiles
+  ansible.windows.win_firewall:
+    state: enabled
+    profiles: "{{ item.profiles | default(omit) }}"
+    inbound_action: "{{ item.inbound_action | default(omit) }}"
+    outbound_action: "{{ item.outbound_action | default(omit) }}"
+  loop: "{{ windows_manage_firewall_profiles_enable | select }}"
+  loop_control:
+    label: "{{ item.profiles | default(item) }}"
+
+- name: Disable firewall rules
+  community.windows.win_firewall_rule:
+    state: "{{ item.state | default('present') }}"
+    name: "{{ item.name | default(omit) }}"
+    enabled: false
+    description: "{{ item.description | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
+    localip: "{{ item.localip | default(omit) }}"
+    localport: "{{ item.localport | default(omit) }}"
+    remoteip: "{{ item.remoteip | default(omit) }}"
+    remoteport: "{{ item.remoteport | default(omit) }}"
+    program: "{{ item.program | default(omit) }}"
+    service: "{{ item.service | default(omit) }}"
+    action: "{{ item.action | default(omit) }}"
+    direction: "{{ item.direction | default(omit) }}"
+    protocol: "{{ item.protocol | default(omit) }}"
+    profiles: "{{ item.profiles | default(omit) }}"
+    icmp_type_code: "{{ item.icmp_type_code | default(omit) }}"
+  loop: "{{ windows_manage_firewall_rules_disable | select }}"
+  loop_control:
+    label: "{{ item.name | default(item) }}"
+  when: item not in windows_manage_firewall_rules_enable
+
+- name: Enable firewall rules
+  community.windows.win_firewall_rule:
+    state: present
+    name: "{{ item.name | default(omit) }}"
+    enabled: true
+    description: "{{ item.description | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
+    localip: "{{ item.localip | default(omit) }}"
+    localport: "{{ item.localport | default(omit) }}"
+    remoteip: "{{ item.remoteip | default(omit) }}"
+    remoteport: "{{ item.remoteport | default(omit) }}"
+    program: "{{ item.program | default(omit) }}"
+    service: "{{ item.service | default(omit) }}"
+    action: "{{ item.action | default(omit) }}"
+    direction: "{{ item.direction | default(omit) }}"
+    protocol: "{{ item.protocol | default(omit) }}"
+    profiles: "{{ item.profiles | default(omit) }}"
+    icmp_type_code: "{{ item.icmp_type_code | default(omit) }}"
+  loop: "{{ windows_manage_firewall_rules_enable | select }}"
+  loop_control:
+    label: "{{ item.name | default(item) }}"

--- a/tests/integration/targets/windows_ops_test_windows_manage_firewall/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_firewall/aliases
@@ -1,2 +1,3 @@
 windows
 infra/windows
+role/windows_manage_firewall

--- a/tests/integration/targets/windows_ops_test_windows_manage_firewall/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_firewall/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_firewall/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_firewall/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+windows_manage_firewall_test_rule_name: "Ansible Test Rule - Firewall Integration"
+windows_manage_firewall_test_port: 19876

--- a/tests/integration/targets/windows_ops_test_windows_manage_firewall/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_firewall/tasks/main.yml
@@ -1,0 +1,105 @@
+---
+- name: Test firewall configuration
+  block:
+    # -- Enable a test rule --
+    - name: Enable a test firewall rule
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_firewall
+      vars:
+        windows_manage_firewall_rules_enable:
+          - name: "{{ windows_manage_firewall_test_rule_name }}"
+            localport: "{{ windows_manage_firewall_test_port }}"
+            action: allow
+            direction: in
+            protocol: tcp
+            profiles:
+              - domain
+
+    - name: Verify test rule exists and is enabled
+      ansible.windows.win_powershell:
+        script: |
+          $rule = Get-NetFirewallRule -DisplayName '{{ windows_manage_firewall_test_rule_name }}' -ErrorAction SilentlyContinue
+          $Ansible.Result = @{
+            exists = [bool]$rule
+            enabled = if ($rule) { $rule.Enabled.ToString() } else { 'False' }
+            action = if ($rule) { $rule.Action.ToString() } else { '' }
+          }
+      register: windows_manage_firewall_verify_enable
+      check_mode: false
+      changed_when: false
+
+    - name: Assert test rule is enabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_firewall_verify_enable.result.exists
+          - windows_manage_firewall_verify_enable.result.enabled == 'True'
+          - windows_manage_firewall_verify_enable.result.action == 'Allow'
+        fail_msg: "Test firewall rule was not enabled"
+
+    # -- Idempotency test --
+    - name: Run role again to verify idempotency
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_firewall
+      vars:
+        windows_manage_firewall_rules_enable:
+          - name: "{{ windows_manage_firewall_test_rule_name }}"
+            localport: "{{ windows_manage_firewall_test_port }}"
+            action: allow
+            direction: in
+            protocol: tcp
+            profiles:
+              - domain
+
+    - name: Verify rule still enabled after idempotent re-run
+      ansible.windows.win_powershell:
+        script: |
+          $rule = Get-NetFirewallRule -DisplayName '{{ windows_manage_firewall_test_rule_name }}' -ErrorAction SilentlyContinue
+          $Ansible.Result = @{
+            exists = [bool]$rule
+            enabled = if ($rule) { $rule.Enabled.ToString() } else { 'False' }
+          }
+      register: windows_manage_firewall_verify_idempotent
+      check_mode: false
+      changed_when: false
+
+    - name: Assert rule unchanged after idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_firewall_verify_idempotent.result.exists
+          - windows_manage_firewall_verify_idempotent.result.enabled == 'True'
+        fail_msg: "Role is not idempotent"
+
+    # -- Disable the test rule --
+    - name: Disable the test firewall rule
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_firewall
+      vars:
+        windows_manage_firewall_rules_disable:
+          - name: "{{ windows_manage_firewall_test_rule_name }}"
+            localport: "{{ windows_manage_firewall_test_port }}"
+            action: allow
+            direction: in
+            protocol: tcp
+
+    - name: Verify test rule is disabled
+      ansible.windows.win_powershell:
+        script: |
+          $rule = Get-NetFirewallRule -DisplayName '{{ windows_manage_firewall_test_rule_name }}' -ErrorAction SilentlyContinue
+          $Ansible.Result = @{
+            enabled = if ($rule) { $rule.Enabled.ToString() } else { 'NotFound' }
+          }
+      register: windows_manage_firewall_verify_disable
+      check_mode: false
+      changed_when: false
+
+    - name: Assert test rule is disabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_firewall_verify_disable.result.enabled == 'False'
+        fail_msg: "Test firewall rule was not disabled"
+
+  always:
+    - name: Clean up test firewall rule
+      community.windows.win_firewall_rule:
+        name: "{{ windows_manage_firewall_test_rule_name }}"
+        state: absent

--- a/tests/integration/targets/windows_ops_test_windows_manage_firewall/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_firewall/tasks/main.yml
@@ -49,6 +49,13 @@
             protocol: tcp
             profiles:
               - domain
+      register: windows_manage_firewall_idempotency_result
+
+    - name: Assert no changes on idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_firewall_idempotency_result.changed
+        fail_msg: "Role reported changes on idempotent re-run"
 
     - name: Verify rule still enabled after idempotent re-run
       ansible.windows.win_powershell:


### PR DESCRIPTION
##### SUMMARY

New `windows_manage_firewall` role migrated from `myllynen/windows-ansible-roles` (`firewall_configuration`).

Data-driven role to enable/disable Windows firewall profiles (domain, private, public) and individual firewall rules. Includes skip-on-conflict safety logic — items present in both enable and disable lists are skipped from the disable operation.

- Role with `argument_specs`, defaults, and full documentation
- Integration tests covering enable, idempotency, disable, and cleanup
- AAP pattern with survey, playbook, and execution environment
- Changelog fragment

Part of ACA-2792 Batch 3 (Security and Audit).

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

roles/windows_manage_firewall

##### ADDITIONAL INFORMATION

Upstream source: `myllynen/windows-ansible-roles` (`firewall_configuration`)

Uses:
- `ansible.windows.win_firewall` for profile management
- `community.windows.win_firewall_rule` for rule management