### PR TITLE
feat(windows_manage_audit): add role for managing Windows audit policies and rules

### DIFF
--- a/changelogs/fragments/add-windows-manage-audit.yml
+++ b/changelogs/fragments/add-windows-manage-audit.yml
@@ -1,4 +1,5 @@
 ---
 minor_changes:
   - "windows_manage_audit - new role for managing Windows audit policies and audit rules with system-wide
-    policy configuration and path-specific rule management."
+    policy configuration and path-specific rule management
+    (https://github.com/redhat-cop/infra.windows_ops/pull/77)."

--- a/changelogs/fragments/add-windows-manage-audit.yml
+++ b/changelogs/fragments/add-windows-manage-audit.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "windows_manage_audit - new role for managing Windows audit policies and audit rules with system-wide
+    policy configuration and path-specific rule management."

--- a/extensions/patterns/manage_audit/README.md
+++ b/extensions/patterns/manage_audit/README.md
@@ -1,0 +1,53 @@
+# Windows Audit Pattern
+
+## Description
+
+This pattern is designed to facilitate the automated management of Windows audit policies and audit rules using Ansible. It provides a streamlined way to seed the necessary resources to configure system-wide audit policies and path-specific audit rules.
+
+## What This Pattern Covers
+
+This pattern includes the following key components:
+
+### Project Templates
+
+- **Manage Audit Project Template**: Defined within the `setup.yaml` playbook, this template helps organize and manage all necessary components for the manage audit pattern. It ensures that relevant files, roles, and configurations are logically arranged, making it easier to maintain and execute automation tasks.
+
+### Playbooks
+
+- **Playbooks**: Located in the playbooks directory, these scripts are specifically designed to execute the `windows_manage_audit` role with the appropriate variables.
+
+### Surveys
+
+- **Manage Audit Surveys**: Defined within the `manage_audit.yaml` file, manage audit surveys provide a dynamic interaction mechanism for users to specify parameters for the audit configuration jobs. These surveys enable users to:
+  - Choose the audit policy category
+  - Choose the audit type (success, failure, or both)
+
+## Resources Created by This Pattern
+
+1. **Project Templates**
+    - Ensure that all relevant files, roles, and configurations are logically arranged, facilitating easier maintenance and execution of automation tasks.
+
+2. **Job Templates**
+    - Outline the necessary parameters and configurations to perform management of audit policies and rules using the provided playbooks.
+
+## How to Use
+
+1. **Use Seed Red Hat pattern Job**
+    - Ensure the custom EE is correctly built and available in your Ansible Automation Platform. Execute the "Seed Red Hat pattern" job within the Ansible Automation Platform, and select the "Windows" category to load this pattern.
+
+2. **Use the Job Templates**
+    - In the `Windows Operations / Manage Audit` execute the required job templates to manage audit configurations. Monitor the job execution and verify that the audit policies are correctly applied.
+
+## Contribution
+
+Contributions to this project are welcome. Please fork the repository, make your changes, and submit a pull request.
+
+## License
+
+GNU General Public License v3.0 or later.
+
+See [LICENSE](https://www.gnu.org/licenses/gpl-3.0.txt) to see the full text. This project is licensed under the MIT License. See the [LICENSE](https://github.com/redhat-cop/infra.windows_ops/blob/main/LICENSE) file for details.
+
+---
+
+For any issues or questions, please open an issue on the [GitHub issue tracker](https://github.com/redhat-cop/infra.windows_ops/issues).

--- a/extensions/patterns/manage_audit/README.md
+++ b/extensions/patterns/manage_audit/README.md
@@ -46,7 +46,7 @@ Contributions to this project are welcome. Please fork the repository, make your
 
 GNU General Public License v3.0 or later.
 
-See [LICENSE](https://www.gnu.org/licenses/gpl-3.0.txt) to see the full text. This project is licensed under the MIT License. See the [LICENSE](https://github.com/redhat-cop/infra.windows_ops/blob/main/LICENSE) file for details.
+See [LICENSE](https://www.gnu.org/licenses/gpl-3.0.txt) to see the full text. See the [LICENSE](https://github.com/redhat-cop/infra.windows_ops/blob/main/LICENSE) file for details.
 
 ---
 

--- a/extensions/patterns/manage_audit/exec_env/README.md
+++ b/extensions/patterns/manage_audit/exec_env/README.md
@@ -1,0 +1,7 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_audit/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_audit/exec_env/execution-environment.yml
@@ -1,0 +1,13 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner
+  system:
+    - podman

--- a/extensions/patterns/manage_audit/exec_env/requirements.yml
+++ b/extensions/patterns/manage_audit/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_audit/playbooks/run_manage_audit.yml
+++ b/extensions/patterns/manage_audit/playbooks/run_manage_audit.yml
@@ -1,0 +1,9 @@
+---
+- name: Manage Windows Audit Configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Manage Windows Audit
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_audit
+...

--- a/extensions/patterns/manage_audit/playbooks/run_manage_audit.yml
+++ b/extensions/patterns/manage_audit/playbooks/run_manage_audit.yml
@@ -6,4 +6,8 @@
     - name: Manage Windows Audit
       ansible.builtin.include_role:
         name: infra.windows_ops.windows_manage_audit
+      vars:
+        windows_manage_audit_system_policies:
+          - category: "{{ audit_category }}"
+            audit_type: "{{ audit_type.split(',') }}"
 ...

--- a/extensions/patterns/manage_audit/setup.yml
+++ b/extensions/patterns/manage_audit/setup.yml
@@ -1,0 +1,55 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_audit_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_audit
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of Windows audit
+      policies and rules. It organizes all necessary resources, including playbooks, job templates,
+      and surveys, to ensure seamless management of audit configurations.
+    organization: Default
+    scm_branch: main
+    scm_clean: 'no'
+    scm_delete_on_update: 'no'
+    scm_type: git
+    scm_update_on_launch: 'yes'
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Audit
+    description: >
+      This job template manages Windows audit policies and audit rules,
+      configuring system-wide policies and path-specific rules as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_audit_pattern
+      - run_manage_audit
+    playbook: "extensions/patterns/manage_audit/playbooks/run_manage_audit.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_audit.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_audit/template_surveys/manage_audit.yml
+++ b/extensions/patterns/manage_audit/template_surveys/manage_audit.yml
@@ -1,0 +1,29 @@
+---
+name: "Manage Audit Configuration Survey"
+description: "Survey to configure Windows audit policy settings"
+spec:
+  - question_name: "Audit Category"
+    question_description: "Select the audit policy category to configure"
+    required: true
+    variable: "audit_category"
+    type: "multiplechoice"
+    choices:
+      - "Account Logon"
+      - "Account Management"
+      - "Detailed Tracking"
+      - "DS Access"
+      - "Logon/Logoff"
+      - "Object Access"
+      - "Policy Change"
+      - "Privilege Use"
+      - "System"
+
+  - question_name: "Audit Type"
+    question_description: "Select the audit type to enable"
+    required: true
+    variable: "audit_type"
+    type: "multiplechoice"
+    choices:
+      - "success"
+      - "failure"
+      - "success,failure"

--- a/roles/windows_manage_audit/README.md
+++ b/roles/windows_manage_audit/README.md
@@ -1,0 +1,69 @@
+# windows_manage_audit
+
+Manage Windows audit policies and audit rules.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Description | Type | Default |
+|----------|-------------|------|---------|
+| **windows_manage_audit_system_policies** | System-wide audit policy settings | list(dict) | `[]` |
+| **windows_manage_audit_ignore_missing** | Ignore errors for missing rules on remove | bool | `false` |
+| **windows_manage_audit_rules_remove** | Audit rules to remove | list(dict) | `[]` |
+| **windows_manage_audit_rules_create** | Audit rules to create | list(dict) | `[]` |
+
+### System Policy Items
+
+Each item in `windows_manage_audit_system_policies` should include:
+- `audit_type`: List of audit types (`success`, `failure`)
+- `category` or `subcategory`: The audit category or subcategory name
+
+### Audit Rule Items
+
+Each item in `windows_manage_audit_rules_create` and `windows_manage_audit_rules_remove` should include:
+- `path`: Filesystem path or registry key (e.g., `C:\Windows\Temp`, `HKLM:\SOFTWARE`)
+- `user`: User or group (e.g., `BUILTIN\Users`)
+- `rights` (create only): List of access rights (e.g., `delete`, `readdata`)
+- `audit_flags` (create only): List of audit flags (`success`, `failure`)
+
+Rules scheduled for removal are skipped when a matching create rule exists for the same path and user.
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+- hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_audit
+      vars:
+        windows_manage_audit_system_policies:
+          - category: Account Logon
+            audit_type:
+              - success
+              - failure
+          - subcategory: File System
+            audit_type:
+              - failure
+        windows_manage_audit_rules_create:
+          - path: HKLM:\SOFTWARE
+            user: BUILTIN\Users
+            rights:
+              - delete
+            audit_flags:
+              - success
+```
+
+## License
+
+GPL-3.0-or-later
+
+## Author
+
+Red Hat Ansible Content Team

--- a/roles/windows_manage_audit/defaults/main.yml
+++ b/roles/windows_manage_audit/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+windows_manage_audit_system_policies: []
+windows_manage_audit_ignore_missing: false
+windows_manage_audit_rules_remove: []
+windows_manage_audit_rules_create: []

--- a/roles/windows_manage_audit/meta/argument_specs.yml
+++ b/roles/windows_manage_audit/meta/argument_specs.yml
@@ -1,0 +1,38 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Manage Windows audit policies and audit rules.
+    description:
+      - Configure system-wide audit policies by category or subcategory.
+      - Create and remove audit rules on filesystem paths and registry keys.
+      - Rules scheduled for removal are skipped when a matching create rule exists.
+    options:
+      windows_manage_audit_system_policies:
+        type: list
+        elements: dict
+        description:
+          - List of system-wide audit policy settings to apply.
+          - Each item must include C(audit_type) and either C(category) or C(subcategory).
+        default: []
+      windows_manage_audit_ignore_missing:
+        type: bool
+        description:
+          - Ignore errors when removing audit rules for paths or users that do not exist.
+        default: false
+      windows_manage_audit_rules_remove:
+        type: list
+        elements: dict
+        description:
+          - List of audit rules to remove.
+          - Each item must include C(path) and C(user).
+          - Items also present in C(windows_manage_audit_rules_create) are skipped.
+        default: []
+      windows_manage_audit_rules_create:
+        type: list
+        elements: dict
+        description:
+          - List of audit rules to create.
+          - Each item must include C(path), C(user), and optionally C(rights), C(audit_flags),
+            C(inheritance_flags), and C(propagation_flags).
+        default: []

--- a/roles/windows_manage_audit/meta/main.yml
+++ b/roles/windows_manage_audit/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  role_name: windows_manage_audit
+  author: Red Hat
+  company: Red Hat, Inc.
+  description: Manage Windows audit policies and audit rules
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - audit
+    - security
+    - configuration
+dependencies: []

--- a/roles/windows_manage_audit/tasks/main.yml
+++ b/roles/windows_manage_audit/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+- name: Configure system-wide audit policies
+  ansible.windows.win_audit_policy_system:
+    audit_type: "{{ item.audit_type }}"
+    category: "{{ item.category | default(omit) }}"
+    subcategory: "{{ item.subcategory | default(omit) }}"
+  loop: "{{ windows_manage_audit_system_policies | select }}"
+  loop_control:
+    label: "{{ item.category | default(item.subcategory) }}"
+
+- name: Remove audit rules
+  ansible.windows.win_audit_rule:
+    path: "{{ item.path }}"
+    user: "{{ item.user }}"
+    state: absent
+  register: windows_manage_audit_removed_rules
+  failed_when:
+    - windows_manage_audit_removed_rules.msg is defined
+    - not windows_manage_audit_ignore_missing | bool or
+      ('not found/invalid' not in windows_manage_audit_removed_rules.msg and
+       'lookup the identity' not in windows_manage_audit_removed_rules.msg)
+  loop: "{{ windows_manage_audit_rules_remove | select }}"
+  loop_control:
+    label: "{{ item.user + ' -> ' + item.path }}"
+  when: windows_manage_audit_rules_create
+        | selectattr('path', 'equalto', item.path)
+        | selectattr('user', 'equalto', item.user)
+        | length == 0
+
+- name: Create audit rules
+  ansible.windows.win_audit_rule:
+    path: "{{ item.path }}"
+    user: "{{ item.user }}"
+    rights: "{{ item.rights | default(omit) }}"
+    audit_flags: "{{ item.audit_flags | default(omit) }}"
+    inheritance_flags: "{{ item.inheritance_flags | default(omit) }}"
+    propagation_flags: "{{ item.propagation_flags | default(omit) }}"
+    state: present
+  loop: "{{ windows_manage_audit_rules_create | select }}"
+  loop_control:
+    label: "{{ item.user + ' -> ' + item.path }}"

--- a/roles/windows_manage_audit/tasks/main.yml
+++ b/roles/windows_manage_audit/tasks/main.yml
@@ -14,18 +14,20 @@
     user: "{{ item.user }}"
     state: absent
   register: windows_manage_audit_removed_rules
-  failed_when:
-    - windows_manage_audit_removed_rules.msg is defined
-    - not windows_manage_audit_ignore_missing | bool or
-      ('not found/invalid' not in windows_manage_audit_removed_rules.msg and
-       'lookup the identity' not in windows_manage_audit_removed_rules.msg)
+  failed_when: >-
+    windows_manage_audit_removed_rules is failed and
+    (not windows_manage_audit_ignore_missing | bool or
+     (windows_manage_audit_removed_rules.msg is defined and
+      'not found/invalid' not in windows_manage_audit_removed_rules.msg and
+      'lookup the identity' not in windows_manage_audit_removed_rules.msg))
   loop: "{{ windows_manage_audit_rules_remove | select }}"
   loop_control:
     label: "{{ item.user + ' -> ' + item.path }}"
-  when: windows_manage_audit_rules_create
-        | selectattr('path', 'equalto', item.path)
-        | selectattr('user', 'equalto', item.user)
-        | length == 0
+  when: >-
+    windows_manage_audit_rules_create
+    | selectattr('path', 'match', '(?i)' ~ (item.path | regex_escape) ~ '$')
+    | selectattr('user', 'match', '(?i)' ~ (item.user | regex_escape) ~ '$')
+    | length == 0
 
 - name: Create audit rules
   ansible.windows.win_audit_rule:

--- a/tests/integration/targets/windows_ops_test_windows_manage_audit/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_audit/aliases
@@ -1,2 +1,3 @@
 windows
 infra/windows
+role/windows_manage_audit

--- a/tests/integration/targets/windows_ops_test_windows_manage_audit/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_audit/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_audit/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_audit/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+windows_manage_audit_test_path: "C:\\AnsibleAuditTest"
+windows_manage_audit_test_user: "BUILTIN\\Users"

--- a/tests/integration/targets/windows_ops_test_windows_manage_audit/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_audit/tasks/main.yml
@@ -57,6 +57,13 @@
             audit_type:
               - success
               - failure
+      register: windows_manage_audit_idempotency_result
+
+    - name: Assert no changes on idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_audit_idempotency_result.changed
+        fail_msg: "Role reported changes on idempotent re-run"
 
     # -- Create audit rule --
     - name: Create audit rule on test directory
@@ -132,6 +139,26 @@
             user: "{{ windows_manage_audit_test_user }}"
 
   always:
+    - name: Restore original audit policy
+      ansible.windows.win_powershell:
+        script: |
+          # Parse the captured CSV-formatted audit policy
+          $lines = '{{ windows_manage_audit_policy_before.result }}' -split "`n"
+          $header = $lines[0]
+          foreach ($line in $lines[1..-1]) {
+            if ($line -match ',Logon,') {
+              # Extract current setting from CSV: Category,Subcategory,GUID,Inclusion Setting
+              $fields = $line -split ','
+              $setting = $fields[-1].Trim()
+              # Restore using auditpol
+              if ($setting) {
+                auditpol /set /subcategory:"Logon" /$setting
+              }
+            }
+          }
+      when: windows_manage_audit_policy_before is defined
+      failed_when: false
+
     - name: Clean up test directory
       ansible.windows.win_file:
         path: "{{ windows_manage_audit_test_path }}"

--- a/tests/integration/targets/windows_ops_test_windows_manage_audit/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_audit/tasks/main.yml
@@ -1,0 +1,138 @@
+---
+- name: Test audit configuration
+  block:
+    - name: Create test directory for audit rules
+      ansible.windows.win_file:
+        path: "{{ windows_manage_audit_test_path }}"
+        state: directory
+
+    # -- System audit policy --
+    - name: Capture current audit policy for Logon/Logoff
+      ansible.windows.win_powershell:
+        script: |
+          $output = auditpol /get /category:"Logon/Logoff" /r
+          $Ansible.Result = $output
+      register: windows_manage_audit_policy_before
+      check_mode: false
+      changed_when: false
+
+    - name: Configure system audit policy
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_audit
+      vars:
+        windows_manage_audit_system_policies:
+          - subcategory: Logon
+            audit_type:
+              - success
+              - failure
+
+    - name: Verify audit policy was applied
+      ansible.windows.win_powershell:
+        script: |
+          $output = auditpol /get /subcategory:"Logon" /r
+          $lines = $output -split "`n" | Where-Object { $_ -match 'Logon' }
+          $Ansible.Result = @{
+            raw = $output
+            has_success = $lines -match 'Success'
+            has_failure = $lines -match 'Failure'
+          }
+      register: windows_manage_audit_policy_verify
+      check_mode: false
+      changed_when: false
+
+    - name: Assert audit policy includes success and failure
+      ansible.builtin.assert:
+        that:
+          - windows_manage_audit_policy_verify.result.has_success
+          - windows_manage_audit_policy_verify.result.has_failure
+        fail_msg: "Audit policy for Logon was not configured correctly"
+
+    # -- Idempotency --
+    - name: Run audit policy again for idempotency
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_audit
+      vars:
+        windows_manage_audit_system_policies:
+          - subcategory: Logon
+            audit_type:
+              - success
+              - failure
+
+    # -- Create audit rule --
+    - name: Create audit rule on test directory
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_audit
+      vars:
+        windows_manage_audit_rules_create:
+          - path: "{{ windows_manage_audit_test_path }}"
+            user: "{{ windows_manage_audit_test_user }}"
+            rights:
+              - delete
+              - readdata
+            audit_flags:
+              - success
+              - failure
+
+    - name: Verify audit rule was created
+      ansible.windows.win_powershell:
+        script: |
+          $acl = Get-Acl -Path '{{ windows_manage_audit_test_path }}' -Audit
+          $rules = $acl.GetAuditRules($true, $false, [System.Security.Principal.NTAccount])
+          $match = $rules | Where-Object { $_.IdentityReference -eq '{{ windows_manage_audit_test_user }}' }
+          $Ansible.Result = @{
+            found = [bool]$match
+            count = @($match).Count
+          }
+      register: windows_manage_audit_rule_verify
+      check_mode: false
+      changed_when: false
+
+    - name: Assert audit rule exists
+      ansible.builtin.assert:
+        that:
+          - windows_manage_audit_rule_verify.result.found
+        fail_msg: "Audit rule was not created on test directory"
+
+    # -- Remove audit rule --
+    - name: Remove audit rule from test directory
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_audit
+      vars:
+        windows_manage_audit_rules_remove:
+          - path: "{{ windows_manage_audit_test_path }}"
+            user: "{{ windows_manage_audit_test_user }}"
+
+    - name: Verify audit rule was removed
+      ansible.windows.win_powershell:
+        script: |
+          $acl = Get-Acl -Path '{{ windows_manage_audit_test_path }}' -Audit
+          $rules = $acl.GetAuditRules($true, $false, [System.Security.Principal.NTAccount])
+          $match = $rules | Where-Object { $_.IdentityReference -eq '{{ windows_manage_audit_test_user }}' }
+          $Ansible.Result = @{
+            found = [bool]$match
+          }
+      register: windows_manage_audit_rule_removed_verify
+      check_mode: false
+      changed_when: false
+
+    - name: Assert audit rule was removed
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_audit_rule_removed_verify.result.found
+        fail_msg: "Audit rule was not removed from test directory"
+
+    # -- Ignore missing --
+    - name: Remove non-existent audit rule with ignore_missing
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_audit
+      vars:
+        windows_manage_audit_ignore_missing: true
+        windows_manage_audit_rules_remove:
+          - path: "{{ windows_manage_audit_test_path }}"
+            user: "{{ windows_manage_audit_test_user }}"
+
+  always:
+    - name: Clean up test directory
+      ansible.windows.win_file:
+        path: "{{ windows_manage_audit_test_path }}"
+        state: absent


### PR DESCRIPTION
##### SUMMARY

New `windows_manage_audit` role migrated from `myllynen/windows-ansible-roles` (`audit_configuration`).

Data-driven role to configure system-wide Windows audit policies and manage path-specific audit rules on filesystem paths and registry keys. Features:

- System-wide audit policies by category or subcategory
- Create/remove audit rules with configurable rights and audit flags
- Skip-on-conflict logic (rules in both create and remove lists are skipped from remove)
- `ignore_missing` flag for graceful handling of non-existent paths/users

Includes role, argument_specs, integration tests, AAP pattern, and changelog fragment.

Part of ACA-2792 Batch 3 (Security and Audit).

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

roles/windows_manage_audit

##### ADDITIONAL INFORMATION

Upstream source: `myllynen/windows-ansible-roles` (`audit_configuration`)

Uses:
- `ansible.windows.win_audit_policy_system` for system-wide audit policies
- `ansible.windows.win_audit_rule` for path-specific audit rules