### PR TITLE
feat: add windows_manage_accounts, windows_manage_user_experience, windows_manage_user_settings roles

### DIFF
--- a/changelogs/fragments/add-windows-manage-accounts.yml
+++ b/changelogs/fragments/add-windows-manage-accounts.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - "windows_manage_accounts - new role for managing local Windows user accounts, groups, group memberships, user rights, and profiles
-    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+    (https://github.com/redhat-cop/infra.windows_ops/pull/80)."

--- a/changelogs/fragments/add-windows-manage-accounts.yml
+++ b/changelogs/fragments/add-windows-manage-accounts.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "windows_manage_accounts - new role for managing local Windows user accounts, groups, group memberships, user rights, and profiles
+    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-user-experience.yml
+++ b/changelogs/fragments/add-windows-manage-user-experience.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - "windows_manage_user_experience - new role for configuring Windows user experience settings such as Server Manager auto-launch, network location wizard, and Welcome Screen behavior
-    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+    (https://github.com/redhat-cop/infra.windows_ops/pull/80)."

--- a/changelogs/fragments/add-windows-manage-user-experience.yml
+++ b/changelogs/fragments/add-windows-manage-user-experience.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "windows_manage_user_experience - new role for configuring Windows user experience settings such as Server Manager auto-launch, network location wizard, and Welcome Screen behavior
+    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-user-settings.yml
+++ b/changelogs/fragments/add-windows-manage-user-settings.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "windows_manage_user_settings - new role for applying per-user registry settings across existing and logged-in Windows user profiles
+    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-user-settings.yml
+++ b/changelogs/fragments/add-windows-manage-user-settings.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - "windows_manage_user_settings - new role for applying per-user registry settings across existing and logged-in Windows user profiles
-    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+    (https://github.com/redhat-cop/infra.windows_ops/pull/80)."

--- a/extensions/patterns/manage_accounts/exec_env/README.md
+++ b/extensions/patterns/manage_accounts/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_accounts/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_accounts/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_accounts/exec_env/requirements.yml
+++ b/extensions/patterns/manage_accounts/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_accounts/playbooks/run_manage_accounts.yml
+++ b/extensions/patterns/manage_accounts/playbooks/run_manage_accounts.yml
@@ -1,0 +1,22 @@
+---
+- name: Manage Windows Local Accounts
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Manage local accounts
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_accounts
+      vars:
+        windows_manage_accounts_administrator_enable: "{{ administrator_enable | default(false) | bool }}"  # Set by survey
+        windows_manage_accounts_ansible_user_password_expires: "{{ ansible_user_password_expires | default(false) | bool }}"  # Set by survey
+        windows_manage_accounts_ansible_user_show_on_welcome: "{{ ansible_user_show_on_welcome | default(false) | bool }}"  # Set by survey
+        # List parameters (groups/users/memberships/rights/profiles) are provided via extra_vars.
+        windows_manage_accounts_groups_create: "{{ accounts_groups_create | default([]) }}"
+        windows_manage_accounts_users_create: "{{ accounts_users_create | default([]) }}"
+        windows_manage_accounts_groups_delete: "{{ accounts_groups_delete | default([]) }}"
+        windows_manage_accounts_users_delete: "{{ accounts_users_delete | default([]) }}"
+        windows_manage_accounts_group_members: "{{ accounts_group_members | default([]) }}"
+        windows_manage_accounts_users_rights: "{{ accounts_users_rights | default([]) }}"
+        windows_manage_accounts_profiles_create: "{{ accounts_profiles_create | default([]) }}"
+        windows_manage_accounts_profiles_delete: "{{ accounts_profiles_delete | default([]) }}"
+...

--- a/extensions/patterns/manage_accounts/setup.yml
+++ b/extensions/patterns/manage_accounts/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_accounts_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_accounts
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of local accounts.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of local users, groups, and profiles.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Accounts
+    description: >
+      This job template manages local accounts, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_accounts_pattern
+      - run_manage_accounts
+    playbook: "extensions/patterns/manage_accounts/playbooks/run_manage_accounts.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_accounts.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_accounts/template_surveys/manage_accounts.yml
+++ b/extensions/patterns/manage_accounts/template_surveys/manage_accounts.yml
@@ -1,0 +1,33 @@
+---
+name: "Manage Accounts Survey"
+description: "Survey to configure local account options"
+spec:
+  - question_name: "Enable Administrator Account"
+    question_description: "Enable or disable the built-in Administrator account"
+    required: true
+    variable: "administrator_enable"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Ansible User Password Expires"
+    question_description: "Allow the Ansible connection user's password to expire"
+    required: true
+    variable: "ansible_user_password_expires"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Show Ansible User on Welcome Screen"
+    question_description: "Show or hide the Ansible connection user on the Welcome Screen"
+    required: true
+    variable: "ansible_user_show_on_welcome"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"

--- a/extensions/patterns/manage_user_experience/exec_env/README.md
+++ b/extensions/patterns/manage_user_experience/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_user_experience/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_user_experience/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_user_experience/exec_env/requirements.yml
+++ b/extensions/patterns/manage_user_experience/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_user_experience/playbooks/run_manage_user_experience.yml
+++ b/extensions/patterns/manage_user_experience/playbooks/run_manage_user_experience.yml
@@ -1,0 +1,13 @@
+---
+- name: Manage Windows User Experience Settings
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Configure user experience
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_experience
+      vars:
+        windows_manage_user_experience_server_manager_at_logon: "{{ server_manager_at_logon | default(true) | bool }}"  # Set by survey
+        windows_manage_user_experience_network_location_wizard: "{{ network_location_wizard | default(false) | bool }}"  # Set by survey
+        windows_manage_user_experience_show_last_user_name: "{{ show_last_user_name | default(true) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_user_experience/setup.yml
+++ b/extensions/patterns/manage_user_experience/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_user_experience_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_user_experience
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of Windows user experience settings.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of user experience configurations.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage User Experience
+    description: >
+      This job template manages Windows user experience settings, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_user_experience_pattern
+      - run_manage_user_experience
+    playbook: "extensions/patterns/manage_user_experience/playbooks/run_manage_user_experience.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_user_experience.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_user_experience/template_surveys/manage_user_experience.yml
+++ b/extensions/patterns/manage_user_experience/template_surveys/manage_user_experience.yml
@@ -1,0 +1,33 @@
+---
+name: "Manage User Experience Survey"
+description: "Survey to configure Windows user experience options"
+spec:
+  - question_name: "Open Server Manager at Logon"
+    question_description: "Open Server Manager automatically at logon"
+    required: true
+    variable: "server_manager_at_logon"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Network Location Wizard"
+    question_description: "Enable or disable the new network location wizard"
+    required: true
+    variable: "network_location_wizard"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Show Last User Name"
+    question_description: "Show or hide the last user name on the Welcome Screen"
+    required: true
+    variable: "show_last_user_name"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"

--- a/extensions/patterns/manage_user_settings/exec_env/README.md
+++ b/extensions/patterns/manage_user_settings/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_user_settings/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_user_settings/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_user_settings/exec_env/requirements.yml
+++ b/extensions/patterns/manage_user_settings/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_user_settings/playbooks/run_manage_user_settings.yml
+++ b/extensions/patterns/manage_user_settings/playbooks/run_manage_user_settings.yml
@@ -1,0 +1,14 @@
+---
+- name: Manage Windows User Settings
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Apply user settings
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_settings
+      vars:
+        windows_manage_user_settings_apply_to_logged_in_users: "{{ user_settings_apply_to_logged_in_users | default(true) | bool }}"  # Set by survey
+        # windows_manage_user_settings_registry is a list of dicts and is not
+        # survey-friendly; provide it via extra variables on the job template.
+        windows_manage_user_settings_registry: "{{ user_settings_registry | default([]) }}"
+...

--- a/extensions/patterns/manage_user_settings/setup.yml
+++ b/extensions/patterns/manage_user_settings/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_user_settings_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_user_settings
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of user settings.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of per-user registry settings.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage User Settings
+    description: >
+      This job template applies per-user registry settings, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_user_settings_pattern
+      - run_manage_user_settings
+    playbook: "extensions/patterns/manage_user_settings/playbooks/run_manage_user_settings.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_user_settings.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_user_settings/template_surveys/manage_user_settings.yml
+++ b/extensions/patterns/manage_user_settings/template_surveys/manage_user_settings.yml
@@ -1,0 +1,15 @@
+---
+name: "Manage User Settings Survey"
+description: "Survey to configure how per-user registry settings are applied"
+spec:
+  - question_name: "Apply to Logged In Users"
+    question_description: "Apply settings to users who are currently logged in (via become)"
+    required: true
+    variable: "user_settings_apply_to_logged_in_users"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+  # NOTE: windows_manage_user_settings_registry is a list of dicts and is not
+  # survey-friendly. Provide it via extra variables on the job template.

--- a/roles/windows_manage_accounts/README.md
+++ b/roles/windows_manage_accounts/README.md
@@ -1,0 +1,57 @@
+# windows_manage_accounts
+
+Manage local Windows user accounts, groups, group memberships, user rights, and profiles.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_accounts_administrator_enable` | bool | `false` | Enable or disable the built-in Administrator account |
+| `windows_manage_accounts_ansible_user_password_expires` | bool | `false` | Allow the Ansible connection user's password to expire |
+| `windows_manage_accounts_ansible_user_show_on_welcome` | bool | `false` | Show or hide the Ansible connection user on the Welcome Screen |
+| `windows_manage_accounts_no_log` | bool | `true` | Value for `no_log` on tasks that set passwords |
+| `windows_manage_accounts_profiles_delete` | list(str) | `[]` | User profiles to delete (user name or SID) |
+| `windows_manage_accounts_users_delete` | list(str) | `[]` | Local users to delete |
+| `windows_manage_accounts_groups_delete` | list(str) | `[]` | Local groups to delete |
+| `windows_manage_accounts_groups_create` | list(dict) | `[]` | Local groups to create (`name`, `description`, `members`) |
+| `windows_manage_accounts_users_create` | list(dict) | `[]` | Local users to create (`name` plus optional attributes) |
+| `windows_manage_accounts_group_members` | list(dict) | `[]` | Group memberships to configure (`name`, `members`, `state`) |
+| `windows_manage_accounts_users_rights` | list(dict) | `[]` | User rights to configure (`name`, `users`, `action`) |
+| `windows_manage_accounts_profiles_create` | list(dict) | `[]` | User profiles to create (`username`, optional `name`) |
+
+Reserved account names (`administrator`, `guest`, `krbtgt`, `local`, `none`) are never created or
+deleted. The role refuses to disable the Administrator account when it is the connecting user.
+
+## Example Playbook
+
+```yaml
+- name: Manage local accounts
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_accounts
+      vars:
+        windows_manage_accounts_groups_create:
+          - name: testgroup
+            description: Test Group
+        windows_manage_accounts_users_create:
+          - name: testuser
+            fullname: Test User
+            description: User for testing
+            password: Foobar_12
+            groups:
+              - Users
+        windows_manage_accounts_group_members:
+          - name: testgroup
+            members:
+              - testuser
+            state: pure
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_accounts/defaults/main.yml
+++ b/roles/windows_manage_accounts/defaults/main.yml
@@ -1,0 +1,75 @@
+---
+# Enable or disable the built-in Administrator account
+windows_manage_accounts_administrator_enable: false
+
+# Allow the Ansible connection user's password to expire
+windows_manage_accounts_ansible_user_password_expires: false
+
+# Show or hide the Ansible connection user on the Welcome Screen
+windows_manage_accounts_ansible_user_show_on_welcome: false
+
+# List of user profiles to delete (user name or SID)
+# NB. Removes all matching profiles
+windows_manage_accounts_profiles_delete: []
+#  - testuser
+#  - S-1-5-21-...-1000
+
+# List of local users to delete
+windows_manage_accounts_users_delete: []
+#  - testuser
+
+# List of local groups to delete
+windows_manage_accounts_groups_delete: []
+#  - testgroup
+
+# List of local groups to create
+# Mandatory parameters: name
+windows_manage_accounts_groups_create: []
+#  - name: testgroup
+#    description: Test Group
+
+# List of local users to create
+# Mandatory parameters: name
+# All users should be added to Users
+windows_manage_accounts_users_create: []
+#  - name: testuser
+#    fullname: Test User
+#    description: User for testing
+#    password: Foobar_12
+#    password_expired: false
+#    password_never_expires: true
+#    user_cannot_change_password: false
+#    groups_action: add
+#    groups:
+#      - Users
+#    account_disabled: false
+#    account_expires: never
+#    account_locked: false
+#    login_script: C:\Users\login.ps1
+#    home_directory: C:\Users\testuser
+
+# Value for the no_log parameter when setting passwords
+windows_manage_accounts_no_log: true
+
+# List of local group memberships to configure
+# Mandatory parameters: name, members, state
+# Set state to pure to make membership explicit
+windows_manage_accounts_group_members: []
+#  - name: testgroup
+#    members:
+#      - testuser
+#    state: pure
+
+# List of local rights settings to configure
+# Mandatory parameters: name, users, action
+windows_manage_accounts_users_rights: []
+#  - name: SeCreateSymbolicLinkPrivilege
+#    users:
+#      - testuser
+#    action: remove
+
+# List of user profiles to create
+# Mandatory parameters: username
+windows_manage_accounts_profiles_create: []
+#  - username: testuser
+#    name: test-testuser

--- a/roles/windows_manage_accounts/meta/argument_specs.yml
+++ b/roles/windows_manage_accounts/meta/argument_specs.yml
@@ -1,0 +1,94 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Manage local Windows user accounts.
+    description:
+      - Manage local user accounts, groups, group memberships, user rights, and user profiles.
+      - Enable or disable the built-in Administrator account and configure the Ansible connection user.
+      - "B(NOTE): The role refuses to disable the Administrator account when it is the connecting user.
+        The check uses C(ansible.builtin.assert) which can be bypassed by wrapping the role call in a
+        C(rescue) block."
+    options:
+      windows_manage_accounts_administrator_enable:
+        type: bool
+        description:
+          - Enable or disable the built-in Administrator account.
+        default: false
+      windows_manage_accounts_ansible_user_password_expires:
+        type: bool
+        description:
+          - Allow the Ansible connection user's password to expire.
+          - When C(false), the connecting user is set to never expire.
+        default: false
+      windows_manage_accounts_ansible_user_show_on_welcome:
+        type: bool
+        description:
+          - Show or hide the Ansible connection user on the Welcome Screen.
+        default: false
+      windows_manage_accounts_no_log:
+        type: bool
+        description:
+          - Value for the C(no_log) parameter on tasks that set user passwords.
+          - Set to C(false) only for debugging; leaving it C(true) prevents passwords appearing in logs.
+        default: true
+      windows_manage_accounts_profiles_delete:
+        type: list
+        elements: str
+        description:
+          - List of user profiles to delete, identified by user name or SID.
+          - Reserved accounts and users present in C(windows_manage_accounts_users_create) are skipped.
+        default: []
+      windows_manage_accounts_users_delete:
+        type: list
+        elements: str
+        description:
+          - List of local users to delete.
+          - Reserved accounts and users present in C(windows_manage_accounts_users_create) are skipped.
+        default: []
+      windows_manage_accounts_groups_delete:
+        type: list
+        elements: str
+        description:
+          - List of local groups to delete.
+          - Reserved accounts and groups present in C(windows_manage_accounts_groups_create) are skipped.
+        default: []
+      windows_manage_accounts_groups_create:
+        type: list
+        elements: dict
+        description:
+          - List of local groups to create.
+          - Each item must include C(name) and may include C(description) and C(members).
+        default: []
+      windows_manage_accounts_users_create:
+        type: list
+        elements: dict
+        description:
+          - List of local users to create.
+          - Each item must include C(name) and may include C(fullname), C(description), C(password),
+            C(password_expired), C(password_never_expires), C(user_cannot_change_password),
+            C(groups_action), C(groups), C(account_disabled), C(account_expires), C(account_locked),
+            C(login_script), and C(home_directory).
+        default: []
+      windows_manage_accounts_group_members:
+        type: list
+        elements: dict
+        description:
+          - List of local group memberships to configure.
+          - Each item must include C(name), C(members), and C(state).
+          - Set C(state) to C(pure) to make membership explicit.
+        default: []
+      windows_manage_accounts_users_rights:
+        type: list
+        elements: dict
+        description:
+          - List of local user rights settings to configure.
+          - Each item must include C(name), C(users), and C(action).
+        default: []
+      windows_manage_accounts_profiles_create:
+        type: list
+        elements: dict
+        description:
+          - List of user profiles to create.
+          - Each item must include C(username) and may include C(name).
+        default: []

--- a/roles/windows_manage_accounts/meta/main.yml
+++ b/roles/windows_manage_accounts/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  role_name: windows_manage_accounts
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Manage local Windows user accounts, groups, group memberships, rights, and profiles.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - accounts
+    - users
+    - groups
+    - configuration
+dependencies: []

--- a/roles/windows_manage_accounts/tasks/main.yml
+++ b/roles/windows_manage_accounts/tasks/main.yml
@@ -1,0 +1,178 @@
+---
+- name: Check connecting user
+  vars:
+    windows_manage_accounts__conn_user: "{{ 'ansible_' + ansible_connection + '_user' }}"
+    windows_manage_accounts__remote_user: "{{ lookup('vars', windows_manage_accounts__conn_user, default='') | default(ansible_user, true) }}"
+  ansible.builtin.set_fact:
+    windows_manage_accounts__ansible_user: "{{ windows_manage_accounts__remote_user | default(lookup('env', 'USER'), true) }}"
+
+- name: Ensure the Administrator account is not disabling itself
+  ansible.builtin.assert:
+    that:
+      - windows_manage_accounts_administrator_enable | bool or
+        windows_manage_accounts__ansible_user | lower != 'administrator'
+    fail_msg: "Refusing to disable Administrator own account."
+    quiet: true
+
+- name: Disable built-in Administrator account
+  ansible.windows.win_user:
+    name: Administrator
+    account_disabled: true
+  when: not windows_manage_accounts_administrator_enable | bool
+
+- name: Enable built-in Administrator account
+  ansible.windows.win_user:
+    name: Administrator
+    account_disabled: false
+  when: windows_manage_accounts_administrator_enable | bool
+
+- name: Configure password expiration for Ansible user
+  ansible.windows.win_user:
+    name: "{{ windows_manage_accounts__ansible_user }}"
+    password_never_expires: "{{ not windows_manage_accounts_ansible_user_password_expires | bool }}"
+  when: windows_manage_accounts__ansible_user | lower != 'administrator'
+
+- name: Configure showing Ansible user on Welcome Screen
+  ansible.windows.win_regedit:
+    path: HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\SpecialAccounts\UserList
+    name: "{{ windows_manage_accounts__ansible_user }}"
+    type: dword
+    data: "{{ 1 if windows_manage_accounts_ansible_user_show_on_welcome | bool else 0 }}"
+  when: windows_manage_accounts__ansible_user | lower != 'administrator'
+
+- name: Delete local profile
+  vars:
+    windows_manage_accounts__name_param: "{{ item if not item.startswith('S-') else omit }}"
+    windows_manage_accounts__username_param: "{{ item if item.startswith('S-') else omit }}"
+  ansible.windows.win_user_profile:
+    name: "{{ windows_manage_accounts__name_param }}"
+    username: "{{ windows_manage_accounts__username_param }}"
+    state: absent
+    remove_multiple: true
+  loop: "{{ windows_manage_accounts_profiles_delete }}"
+  when:
+    - item | lower not in windows_manage_accounts__reserved_names
+    - item not in windows_manage_accounts_users_create | map(attribute='name')
+
+- name: Delete local user
+  ansible.windows.win_user:
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ windows_manage_accounts_users_delete }}"
+  when:
+    - item | lower not in windows_manage_accounts__reserved_names
+    - item not in windows_manage_accounts_users_create | map(attribute='name')
+
+- name: Delete local group
+  ansible.windows.win_group:
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ windows_manage_accounts_groups_delete }}"
+  when:
+    - item | lower not in windows_manage_accounts__reserved_names
+    - item not in windows_manage_accounts_groups_create | map(attribute='name')
+
+# https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-shell-setup-useraccounts-localaccounts-localaccount-name
+- name: Verify local group names
+  ansible.builtin.assert:
+    that:
+      - item.name | length >= 1
+      - item.name | length <= 256
+      - item.name not in ['.', '..']
+      - item.name | lower not in windows_manage_accounts__reserved_names
+      - item.name is not search('[/\\\[\]:|<>+=;,?*%@]')
+    quiet: true
+    fail_msg: "{{ item.name }} is not acceptable group name."
+  loop: "{{ windows_manage_accounts_groups_create }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Create local group
+  ansible.windows.win_group:
+    name: "{{ item.name }}"
+    state: present
+    description: "{{ item.description | default(omit) }}"
+    members: "{{ item.members | default(omit) }}"
+  loop: "{{ windows_manage_accounts_groups_create }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Create passwordless list of local users to create
+  no_log: "{{ windows_manage_accounts_no_log }}"
+  ansible.builtin.set_fact:
+    windows_manage_accounts__create_users: "{{ windows_manage_accounts__create_users | default([]) + [item | dict2items | rejectattr('key', 'equalto', 'password') | items2dict] }}"
+  loop: "{{ windows_manage_accounts_users_create }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+# https://learn.microsoft.com/en-us/windows-hardware/customize/desktop/unattend/microsoft-windows-shell-setup-useraccounts-localaccounts-localaccount-name
+- name: Verify local user names
+  ansible.builtin.assert:
+    that:
+      - item.name | length >= 1
+      - item.name | length <= 256
+      - item.name not in ['.', '..']
+      - item.name | lower not in windows_manage_accounts__reserved_names
+      - item.name is not search('[/\\\[\]:|<>+=;,?*%@]')
+    quiet: true
+    fail_msg: "{{ item.name }} is not acceptable user name."
+  loop: "{{ windows_manage_accounts__create_users | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Create local user
+  # noqa: no-log-password
+  ansible.windows.win_user:
+    name: "{{ item.name }}"
+    state: present
+    fullname: "{{ item.fullname | default(omit) }}"
+    description: "{{ item.description | default(omit) }}"
+    password_expired: "{{ item.password_expired | default(omit) }}"
+    password_never_expires: "{{ item.password_never_expires | default(omit) }}"
+    user_cannot_change_password: "{{ item.user_cannot_change_password | default(omit) }}"
+    groups_action: "{{ item.groups_action | default(omit) }}"
+    groups: "{{ item.groups | default(omit) }}"
+    account_disabled: "{{ item.account_disabled | default(omit) }}"
+    account_expires: "{{ item.account_expires | default(omit) }}"
+    account_locked: "{{ item.account_locked | default(omit) }}"
+    login_script: "{{ item.login_script | default(omit) }}"
+    home_directory: "{{ item.home_directory | default(omit) }}"
+  loop: "{{ windows_manage_accounts__create_users | default([]) }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Update local user password
+  no_log: "{{ windows_manage_accounts_no_log }}"
+  ansible.windows.win_user:
+    name: "{{ item.name }}"
+    password: "{{ item.password }}"
+  loop: "{{ windows_manage_accounts_users_create | selectattr('password', 'defined') }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Configure local group membership
+  ansible.windows.win_group_membership:
+    name: "{{ item.name }}"
+    members: "{{ item.members }}"
+    state: "{{ item.state }}"
+  loop: "{{ windows_manage_accounts_group_members }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Configure local rights
+  ansible.windows.win_user_right:
+    name: "{{ item.name }}"
+    users: "{{ item.users }}"
+    action: "{{ item.action }}"
+  loop: "{{ windows_manage_accounts_users_rights }}"
+  loop_control:
+    label: "{{ item.name }}"
+
+- name: Create local profile
+  ansible.windows.win_user_profile:
+    name: "{{ item.name | default(omit) }}"
+    username: "{{ item.username }}"
+    state: present
+  loop: "{{ windows_manage_accounts_profiles_create }}"
+  loop_control:
+    label: "{{ item.username }}"

--- a/roles/windows_manage_accounts/vars/main.yml
+++ b/roles/windows_manage_accounts/vars/main.yml
@@ -1,0 +1,8 @@
+---
+# Reserved account names that must never be created or deleted by this role.
+windows_manage_accounts__reserved_names:
+  - administrator
+  - guest
+  - krbtgt
+  - local
+  - none

--- a/roles/windows_manage_user_experience/README.md
+++ b/roles/windows_manage_user_experience/README.md
@@ -1,0 +1,33 @@
+# windows_manage_user_experience
+
+Configure Windows user experience settings such as Server Manager auto-launch, network location wizard, and Welcome Screen behavior.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_user_experience_server_manager_at_logon` | bool | `true` | Open Server Manager automatically at logon |
+| `windows_manage_user_experience_network_location_wizard` | bool | `false` | Enable or disable the new network location wizard |
+| `windows_manage_user_experience_show_last_user_name` | bool | `true` | Show or hide the last user name on the Welcome Screen |
+
+## Example Playbook
+
+```yaml
+- name: Configure user experience
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_user_experience
+      vars:
+        windows_manage_user_experience_server_manager_at_logon: false
+        windows_manage_user_experience_network_location_wizard: false
+        windows_manage_user_experience_show_last_user_name: false
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_user_experience/defaults/main.yml
+++ b/roles/windows_manage_user_experience/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Open Server Manager automatically at logon
+windows_manage_user_experience_server_manager_at_logon: true
+
+# Enable or disable the new network location wizard
+windows_manage_user_experience_network_location_wizard: false
+
+# Show or hide the last user name on the Welcome Screen
+windows_manage_user_experience_show_last_user_name: true

--- a/roles/windows_manage_user_experience/meta/argument_specs.yml
+++ b/roles/windows_manage_user_experience/meta/argument_specs.yml
@@ -1,0 +1,28 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Configure Windows user experience settings.
+    description:
+      - Configure interactive logon and desktop experience settings on Windows hosts.
+      - Manages Server Manager auto-launch, the new network location wizard, and
+        whether the last user name is shown on the Welcome Screen.
+    options:
+      windows_manage_user_experience_server_manager_at_logon:
+        type: bool
+        description:
+          - Open Server Manager automatically at logon.
+          - Set to C(false) to prevent Server Manager from launching at logon.
+        default: true
+      windows_manage_user_experience_network_location_wizard:
+        type: bool
+        description:
+          - Enable or disable the new network location wizard.
+          - When C(false), the wizard is suppressed for new networks.
+        default: false
+      windows_manage_user_experience_show_last_user_name:
+        type: bool
+        description:
+          - Show or hide the last user name on the Welcome Screen.
+          - Set to C(false) to hide the last signed-in user name.
+        default: true

--- a/roles/windows_manage_user_experience/meta/main.yml
+++ b/roles/windows_manage_user_experience/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: windows_manage_user_experience
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Configure Windows user experience settings such as Server Manager auto-launch, network location wizard, and Welcome Screen behavior.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - configuration
+dependencies: []

--- a/roles/windows_manage_user_experience/tasks/main.yml
+++ b/roles/windows_manage_user_experience/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Configure Server Manager at logon
+  ansible.windows.win_regedit:
+    path: HKLM:\SOFTWARE\Microsoft\ServerManager
+    name: DoNotOpenServerManagerAtLogon
+    type: dword
+    data: "{{ 0 if windows_manage_user_experience_server_manager_at_logon | bool else 1 }}"
+
+- name: Configure new network location wizard
+  ansible.windows.win_regedit:
+    path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+    state: "{{ 'absent' if windows_manage_user_experience_network_location_wizard | bool else 'present' }}"
+
+- name: Configure showing last user name on Welcome Screen
+  ansible.windows.win_regedit:
+    path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+    name: DontDisplayLastUserName
+    type: dword
+    data: "{{ 0 if windows_manage_user_experience_show_last_user_name | bool else 1 }}"

--- a/roles/windows_manage_user_settings/README.md
+++ b/roles/windows_manage_user_settings/README.md
@@ -1,0 +1,60 @@
+# windows_manage_user_settings
+
+Apply per-user registry settings across existing and logged-in Windows user profiles.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_user_settings_apply_to_logged_in_users` | bool | `true` | Apply settings to currently logged-in users via `become` |
+| `windows_manage_user_settings_registry` | list(dict) | `[]` | Registry settings to apply per user profile |
+
+Each `windows_manage_user_settings_registry` item supports:
+
+| Key | Required | Description |
+|---|---|---|
+| `setting` | yes | Human-readable label for the setting |
+| `path` | yes | Registry path (typically under `HKCU:`) |
+| `name` | no | Value name |
+| `type` | no | Value type (e.g. `DWord`, `String`) |
+| `data` | no | Value data |
+| `state` | no | `present` (default) or `absent` |
+
+## Example Playbook
+
+```yaml
+- name: Apply user settings
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_user_settings
+      vars:
+        windows_manage_user_settings_apply_to_logged_in_users: true
+        windows_manage_user_settings_registry:
+          - setting: Minimize Visual Effects for Performance
+            path: HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects
+            name: VisualFXSetting
+            type: DWord
+            data: 2
+          - setting: Disable Taskbar Animations
+            path: HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+            name: TaskbarAnimations
+            type: DWord
+            data: 0
+```
+
+## How it works
+
+Each `HKCU:` setting is applied to every existing user profile by loading that
+profile's `NTUSER.DAT` hive. For users who are currently logged in the hive is
+locked; when `windows_manage_user_settings_apply_to_logged_in_users` is `true`
+those settings are re-applied via `become` in the user's own context. The
+connecting Ansible user's own profile is intentionally excluded.
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_user_settings/defaults/main.yml
+++ b/roles/windows_manage_user_settings/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# Apply settings to users who are currently logged in (their hive is locked).
+# Some settings may only take effect after the user logs in again.
+windows_manage_user_settings_apply_to_logged_in_users: true
+
+# User registry settings to apply with ansible.windows.win_regedit.
+# Each item: setting (label), path, and optionally name, type, data, state.
+# Paths are typically under HKCU: as they are applied per user profile.
+windows_manage_user_settings_registry: []
+#  - setting: Minimize Visual Effects for Performance
+#    path: HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects
+#    name: VisualFXSetting
+#    type: DWord
+#    data: 2
+#
+#  - setting: Disable Taskbar Animations
+#    path: HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+#    name: TaskbarAnimations
+#    type: DWord
+#    data: 0

--- a/roles/windows_manage_user_settings/meta/argument_specs.yml
+++ b/roles/windows_manage_user_settings/meta/argument_specs.yml
@@ -1,0 +1,28 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Apply per-user Windows registry settings.
+    description:
+      - Apply registry settings to existing user profiles by loading each
+        profile's C(NTUSER.DAT) hive.
+      - For users who are currently logged in (whose hive is locked), settings
+        are applied in the user's own context via C(become).
+      - The connecting Ansible user's own profile is intentionally excluded.
+    options:
+      windows_manage_user_settings_apply_to_logged_in_users:
+        type: bool
+        description:
+          - Apply settings to users who are currently logged in by using C(become).
+          - When C(false), profiles whose hive is locked are skipped instead of
+            failing.
+        default: true
+      windows_manage_user_settings_registry:
+        type: list
+        elements: dict
+        description:
+          - List of registry settings to apply to each user profile.
+          - Each item must include C(setting) (a human-readable label) and C(path).
+          - "Optional keys per item: C(name), C(type), C(data), and C(state)."
+          - Paths are typically under C(HKCU:) as they are applied per user profile.
+        default: []

--- a/roles/windows_manage_user_settings/meta/main.yml
+++ b/roles/windows_manage_user_settings/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: windows_manage_user_settings
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Apply per-user registry settings across existing and logged-in Windows user profiles.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - configuration
+dependencies: []

--- a/roles/windows_manage_user_settings/tasks/main.yml
+++ b/roles/windows_manage_user_settings/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+- name: Check connecting user
+  vars:
+    windows_manage_user_settings__conn_user: "{{ 'ansible_' + ansible_connection + '_user' }}"
+    windows_manage_user_settings__remote_user: "{{ lookup('vars', windows_manage_user_settings__conn_user, default='') | default(ansible_user, true) }}"
+  ansible.builtin.set_fact:
+    windows_manage_user_settings__ansible_user: "{{ windows_manage_user_settings__remote_user | default(lookup('env', 'USER'), true) }}"
+
+# There is no native ansible.windows/community.windows module that enumerates all
+# user profiles with SID-to-name translation, so win_powershell is used here.
+- name: Get list of user profiles
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $userProfiles = @()
+      $excludeSIDs = '^S-1-5-(18|19|20)$|^S-1-5-21-\d+-\d+-\d+-(501|503|504)$'
+      $localProfiles = Get-CimInstance -ClassName Win32_UserProfile | Where-Object {
+        -not $_.Special -and $_.SID -notmatch $excludeSIDs
+      } | ForEach-Object {
+        $profileObject = $_
+        try {
+          $userName = ([System.Security.Principal.SecurityIdentifier]$profileObject.SID).Translate([System.Security.Principal.NTAccount]).Value
+        }
+        catch {
+          $userName = $profileObject.SID
+        }
+        if ($userName -notmatch '\\{{ windows_manage_user_settings__ansible_user }}$') {
+          [PSCustomObject]@{
+            UserName  = $userName
+            LocalPath = $profileObject.LocalPath
+          }
+        }
+      } | Where-Object { $_ -ne $null }
+      $userProfiles += $localProfiles
+      $defaultProfile = [PSCustomObject]@{
+        UserName  = 'Default Profile'
+        LocalPath = 'C:\Users\Default'
+      }
+      $userProfiles += $defaultProfile
+      $Ansible.Result = $userProfiles
+  register: windows_manage_user_settings__profiles
+  changed_when: false
+  when: windows_manage_user_settings_registry | length > 0
+
+- name: Configure user registry settings
+  ansible.windows.win_regedit:
+    hive: "{{ item[0].LocalPath }}\\NTUSER.DAT"
+    path: "{{ item[1].path }}"
+    name: "{{ item[1].name | default(omit) }}"
+    type: "{{ item[1].type | default(omit) }}"
+    data: "{{ item[1].data | default(omit) }}"
+    state: "{{ item[1].state | default(omit) }}"
+  register: windows_manage_user_settings__update
+  failed_when:
+    - windows_manage_user_settings__update.msg is defined
+    - windows_manage_user_settings_apply_to_logged_in_users | bool or
+      'used by another process' not in windows_manage_user_settings__update.msg
+  ignore_errors: "{{ windows_manage_user_settings_apply_to_logged_in_users | bool }}"
+  loop: "{{ windows_manage_user_settings__profiles.result | product(windows_manage_user_settings_registry) }}"
+  loop_control:
+    label: "{{ item[0].UserName }} - {{ item[1].setting }}"
+  when: windows_manage_user_settings_registry | length > 0
+
+- name: Apply settings to logged in users
+  vars:
+    windows_manage_user_settings__failed_users: "{{ windows_manage_user_settings__update.results | selectattr('failed', 'equalto', true) | map(attribute='item.0') | unique }}"
+  become: true
+  become_user: "{{ item[0].UserName }}"
+  ansible.windows.win_regedit:
+    path: "{{ item[1].path }}"
+    name: "{{ item[1].name | default(omit) }}"
+    type: "{{ item[1].type | default(omit) }}"
+    data: "{{ item[1].data | default(omit) }}"
+    state: "{{ item[1].state | default(omit) }}"
+  loop: "{{ windows_manage_user_settings__failed_users | product(windows_manage_user_settings_registry) }}"
+  loop_control:
+    label: "{{ item[0].UserName }} - {{ item[1].setting }}"
+  when: windows_manage_user_settings_registry | length > 0

--- a/tests/integration/targets/windows_ops_test_windows_manage_accounts/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_accounts/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_accounts/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_accounts/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Test creates a throwaway group + user, verifies membership, then deletes them.
+# The built-in Administrator account is kept enabled to avoid any lockout risk.
+windows_manage_accounts_test_group: AnsibleTestGroup
+windows_manage_accounts_test_user: ansibletestusr
+windows_manage_accounts_test_password: Ansible_Test_123!

--- a/tests/integration/targets/windows_ops_test_windows_manage_accounts/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_accounts/tasks/main.yml
@@ -1,0 +1,134 @@
+---
+- name: Test local account management
+  block:
+    # -- State A: create group, user, and membership --
+    - name: Create group, user, and membership (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_accounts
+      vars:
+        windows_manage_accounts_administrator_enable: true
+        windows_manage_accounts_groups_create:
+          - name: "{{ windows_manage_accounts_test_group }}"
+            description: Ansible integration test group
+        windows_manage_accounts_users_create:
+          - name: "{{ windows_manage_accounts_test_user }}"
+            fullname: Ansible Test User
+            description: Ansible integration test user
+            password: "{{ windows_manage_accounts_test_password }}"
+            groups:
+              - Users
+        windows_manage_accounts_group_members:
+          - name: "{{ windows_manage_accounts_test_group }}"
+            members:
+              - "{{ windows_manage_accounts_test_user }}"
+            state: pure
+
+    - name: Verify test user exists (check mode reports no change)
+      ansible.windows.win_user:
+        name: "{{ windows_manage_accounts_test_user }}"
+        state: present
+      check_mode: true
+      register: windows_manage_accounts__verify_user_a
+
+    - name: Assert test user exists after state A
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_accounts__verify_user_a.changed
+        fail_msg: "Test user was not created"
+
+    - name: Verify test group membership (check mode reports no change)
+      ansible.windows.win_group_membership:
+        name: "{{ windows_manage_accounts_test_group }}"
+        members:
+          - "{{ windows_manage_accounts_test_user }}"
+        state: pure
+      check_mode: true
+      register: windows_manage_accounts__verify_membership_a
+
+    - name: Assert group membership is configured after state A
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_accounts__verify_membership_a.changed
+        fail_msg: "Test group membership was not configured"
+
+    # -- Idempotency: re-run state A --
+    - name: Re-run state A to verify idempotency
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_accounts
+      vars:
+        windows_manage_accounts_administrator_enable: true
+        windows_manage_accounts_groups_create:
+          - name: "{{ windows_manage_accounts_test_group }}"
+            description: Ansible integration test group
+        windows_manage_accounts_users_create:
+          - name: "{{ windows_manage_accounts_test_user }}"
+            fullname: Ansible Test User
+            description: Ansible integration test user
+            groups:
+              - Users
+        windows_manage_accounts_group_members:
+          - name: "{{ windows_manage_accounts_test_group }}"
+            members:
+              - "{{ windows_manage_accounts_test_user }}"
+            state: pure
+
+    - name: Verify test user still exists after idempotent re-run
+      ansible.windows.win_user:
+        name: "{{ windows_manage_accounts_test_user }}"
+        state: present
+      check_mode: true
+      register: windows_manage_accounts__verify_user_idempotent
+
+    - name: Assert user unchanged after idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_accounts__verify_user_idempotent.changed
+        fail_msg: "Role is not idempotent - user changed on re-run"
+
+    # -- State B: delete user and group --
+    - name: Delete test user and group (state B)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_accounts
+      vars:
+        windows_manage_accounts_administrator_enable: true
+        windows_manage_accounts_users_delete:
+          - "{{ windows_manage_accounts_test_user }}"
+        windows_manage_accounts_groups_delete:
+          - "{{ windows_manage_accounts_test_group }}"
+
+    - name: Verify test user is absent (check mode reports no change)
+      ansible.windows.win_user:
+        name: "{{ windows_manage_accounts_test_user }}"
+        state: absent
+      check_mode: true
+      register: windows_manage_accounts__verify_user_b
+
+    - name: Assert test user is absent after state B
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_accounts__verify_user_b.changed
+        fail_msg: "Test user was not deleted"
+
+    - name: Verify test group is absent (check mode reports no change)
+      ansible.windows.win_group:
+        name: "{{ windows_manage_accounts_test_group }}"
+        state: absent
+      check_mode: true
+      register: windows_manage_accounts__verify_group_b
+
+    - name: Assert test group is absent after state B
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_accounts__verify_group_b.changed
+        fail_msg: "Test group was not deleted"
+
+  always:
+    - name: Clean up test user
+      ansible.windows.win_user:
+        name: "{{ windows_manage_accounts_test_user }}"
+        state: absent
+
+    - name: Clean up test group
+      ansible.windows.win_group:
+        name: "{{ windows_manage_accounts_test_group }}"
+        state: absent

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_experience/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_experience/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_experience/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_experience/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Test toggles the three user experience registry settings across two states
+# and verifies idempotency, then restores the original values.

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_experience/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_experience/tasks/main.yml
@@ -1,0 +1,147 @@
+---
+- name: Test user experience configuration
+  block:
+    - name: Capture original Server Manager at logon setting
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+      register: windows_manage_user_experience__original_srvmgr
+
+    - name: Capture original network location wizard key
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+      register: windows_manage_user_experience__original_netwiz
+
+    - name: Capture original last user name setting
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: DontDisplayLastUserName
+      register: windows_manage_user_experience__original_lastuser
+
+    # -- State A: all settings disabled --
+    - name: Configure user experience (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_experience
+      vars:
+        windows_manage_user_experience_server_manager_at_logon: false
+        windows_manage_user_experience_network_location_wizard: false
+        windows_manage_user_experience_show_last_user_name: false
+
+    - name: Verify Server Manager setting after state A
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+      register: windows_manage_user_experience__verify_srvmgr_a
+
+    - name: Verify network location wizard key after state A
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+      register: windows_manage_user_experience__verify_netwiz_a
+
+    - name: Verify last user name setting after state A
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: DontDisplayLastUserName
+      register: windows_manage_user_experience__verify_lastuser_a
+
+    - name: Assert state A applied
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_experience__verify_srvmgr_a.value == 1
+          - windows_manage_user_experience__verify_netwiz_a.exists
+          - windows_manage_user_experience__verify_lastuser_a.value == 1
+        fail_msg: "State A settings were not applied correctly"
+
+    # -- Idempotency --
+    - name: Run role again to verify idempotency (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_experience
+      vars:
+        windows_manage_user_experience_server_manager_at_logon: false
+        windows_manage_user_experience_network_location_wizard: false
+        windows_manage_user_experience_show_last_user_name: false
+      register: windows_manage_user_experience__idempotent
+
+    - name: Verify settings unchanged after idempotent re-run
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+      register: windows_manage_user_experience__verify_idempotent
+
+    - name: Assert state unchanged after idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_experience__verify_idempotent.value == 1
+        fail_msg: "Role is not idempotent - registry values changed on re-run"
+
+    # -- State B: all settings enabled --
+    - name: Configure user experience (state B)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_experience
+      vars:
+        windows_manage_user_experience_server_manager_at_logon: true
+        windows_manage_user_experience_network_location_wizard: true
+        windows_manage_user_experience_show_last_user_name: true
+
+    - name: Verify Server Manager setting after state B
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+      register: windows_manage_user_experience__verify_srvmgr_b
+
+    - name: Verify network location wizard key after state B
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+      register: windows_manage_user_experience__verify_netwiz_b
+
+    - name: Verify last user name setting after state B
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: DontDisplayLastUserName
+      register: windows_manage_user_experience__verify_lastuser_b
+
+    - name: Assert state B applied
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_experience__verify_srvmgr_b.value == 0
+          - not windows_manage_user_experience__verify_netwiz_b.exists
+          - windows_manage_user_experience__verify_lastuser_b.value == 0
+        fail_msg: "State B settings were not applied correctly"
+
+  always:
+    - name: Restore original Server Manager setting
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+        type: dword
+        data: "{{ windows_manage_user_experience__original_srvmgr.value }}"
+        state: present
+      when: windows_manage_user_experience__original_srvmgr.exists
+
+    - name: Remove Server Manager setting if it did not exist originally
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+        state: absent
+      when: not windows_manage_user_experience__original_srvmgr.exists
+
+    - name: Restore original network location wizard key
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+        state: "{{ 'present' if windows_manage_user_experience__original_netwiz.exists else 'absent' }}"
+
+    - name: Restore original last user name setting
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: DontDisplayLastUserName
+        type: dword
+        data: "{{ windows_manage_user_experience__original_lastuser.value }}"
+        state: present
+      when: windows_manage_user_experience__original_lastuser.exists
+
+    - name: Remove last user name setting if it did not exist originally
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: DontDisplayLastUserName
+        state: absent
+      when: not windows_manage_user_experience__original_lastuser.exists

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_settings/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_settings/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_settings/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_settings/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# The test applies a throwaway HKCU setting to the Default user profile and
+# verifies it by loading the profile hive with reg.exe. The role intentionally
+# excludes the connecting WinRM user's own profile, so the Default profile
+# (always included by the role) is used as the deterministic verification target.

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_settings/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_settings/tasks/main.yml
@@ -1,0 +1,136 @@
+---
+- name: Test user settings configuration
+  vars:
+    windows_manage_user_settings__test_hive_key: 'HKLM\AnsibleUserSettingsTest'
+    windows_manage_user_settings__default_hive: 'C:\Users\Default\NTUSER.DAT'
+    windows_manage_user_settings__verify_path: 'HKLM:\AnsibleUserSettingsTest\SOFTWARE\_ansible_windows_ops_test'
+  block:
+    # -- State A: apply DWord = 1 to the Default profile --
+    - name: Apply user setting (state A - data 1)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_settings
+      vars:
+        windows_manage_user_settings_apply_to_logged_in_users: false
+        windows_manage_user_settings_registry:
+          - setting: Ansible test marker
+            path: 'HKCU:\SOFTWARE\_ansible_windows_ops_test'
+            name: UserSettingsTest
+            type: DWord
+            data: 1
+
+    - name: Load Default profile hive for verification (state A)
+      ansible.windows.win_command: >-
+        reg load {{ windows_manage_user_settings__test_hive_key }}
+        {{ windows_manage_user_settings__default_hive }}
+      changed_when: true
+
+    - name: Read applied value (state A)
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_user_settings__verify_path }}"
+        name: UserSettingsTest
+      register: windows_manage_user_settings__verify_a
+
+    - name: Unload Default profile hive (state A)
+      ansible.windows.win_command: >-
+        reg unload {{ windows_manage_user_settings__test_hive_key }}
+      changed_when: true
+
+    - name: Assert setting applied to Default profile (state A)
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_settings__verify_a.exists
+          - windows_manage_user_settings__verify_a.value == 1
+        fail_msg: "User setting was not applied to the Default profile"
+
+    # -- Idempotency: re-run state A --
+    - name: Apply user setting again (idempotency)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_settings
+      vars:
+        windows_manage_user_settings_apply_to_logged_in_users: false
+        windows_manage_user_settings_registry:
+          - setting: Ansible test marker
+            path: 'HKCU:\SOFTWARE\_ansible_windows_ops_test'
+            name: UserSettingsTest
+            type: DWord
+            data: 1
+
+    - name: Load Default profile hive for verification (idempotency)
+      ansible.windows.win_command: >-
+        reg load {{ windows_manage_user_settings__test_hive_key }}
+        {{ windows_manage_user_settings__default_hive }}
+      changed_when: true
+
+    - name: Read value after idempotent re-run
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_user_settings__verify_path }}"
+        name: UserSettingsTest
+      register: windows_manage_user_settings__verify_idem
+
+    - name: Unload Default profile hive (idempotency)
+      ansible.windows.win_command: >-
+        reg unload {{ windows_manage_user_settings__test_hive_key }}
+      changed_when: true
+
+    - name: Assert value unchanged after idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_settings__verify_idem.value == 1
+        fail_msg: "User setting changed on idempotent re-run"
+
+    # -- State B: apply DWord = 0 --
+    - name: Apply user setting (state B - data 0)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_settings
+      vars:
+        windows_manage_user_settings_apply_to_logged_in_users: false
+        windows_manage_user_settings_registry:
+          - setting: Ansible test marker
+            path: 'HKCU:\SOFTWARE\_ansible_windows_ops_test'
+            name: UserSettingsTest
+            type: DWord
+            data: 0
+
+    - name: Load Default profile hive for verification (state B)
+      ansible.windows.win_command: >-
+        reg load {{ windows_manage_user_settings__test_hive_key }}
+        {{ windows_manage_user_settings__default_hive }}
+      changed_when: true
+
+    - name: Read applied value (state B)
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_user_settings__verify_path }}"
+        name: UserSettingsTest
+      register: windows_manage_user_settings__verify_b
+
+    - name: Unload Default profile hive (state B)
+      ansible.windows.win_command: >-
+        reg unload {{ windows_manage_user_settings__test_hive_key }}
+      changed_when: true
+
+    - name: Assert setting updated in Default profile (state B)
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_settings__verify_b.value == 0
+        fail_msg: "User setting was not updated to 0 in the Default profile"
+
+  always:
+    # Remove the throwaway test key from the Default profile hive.
+    - name: Load Default profile hive for cleanup
+      ansible.windows.win_command: >-
+        reg load {{ windows_manage_user_settings__test_hive_key }}
+        {{ windows_manage_user_settings__default_hive }}
+      changed_when: true
+      failed_when: false
+
+    - name: Remove test key from Default profile
+      ansible.windows.win_command: >-
+        reg delete {{ windows_manage_user_settings__test_hive_key }}\SOFTWARE\_ansible_windows_ops_test /f
+      changed_when: true
+      failed_when: false
+
+    - name: Unload Default profile hive after cleanup
+      ansible.windows.win_command: >-
+        reg unload {{ windows_manage_user_settings__test_hive_key }}
+      changed_when: true
+      failed_when: false


### PR DESCRIPTION
##### SUMMARY

Batch 4 of the Windows content migration (ACA-2792). Adds three roles migrated from the upstream `myllynen/windows-ansible-roles` project:

- **`windows_manage_accounts`** (← `accounts_local`) — manage local users, groups, group memberships, user rights, and profiles, plus the built-in Administrator and the Ansible connection user. Refuses to disable the Administrator account when it is the connecting user.
- **`windows_manage_user_experience`** (← `user_experience`) — configure Server Manager auto-launch, the new network location wizard, and Welcome Screen last-user-name behavior.
- **`windows_manage_user_settings`** (← `user_settings`) — apply per-user registry settings across existing profiles by loading each `NTUSER.DAT` hive, with a `become` fallback for logged-in users whose hive is locked.

Each role ships with `meta/argument_specs.yml`, a README, an AAP pattern (`setup.yml`, playbook, survey, exec-env), and a two-state idempotent integration test with capture/restore.

The migration standards agreed with the upstream author are applied from the start:
- Internal implementation variables use the `windows_manage_<name>__<var>` (double-underscore) form; public variables keep the single-underscore interface.
- No defensive empty/null input filtering — argument spec validation guarantees input types.
- Precondition checks use `ansible.builtin.assert` rather than `ansible.builtin.fail`.

`windows_manage_user_settings` retains a single `win_powershell` task to enumerate user profiles with SID-to-name translation, as no native `ansible.windows`/`community.windows` module covers this.

##### ISSUE TYPE
New Module Pull Request

##### COMPONENT NAME
windows_manage_accounts
windows_manage_user_experience
windows_manage_user_settings

##### ADDITIONAL INFORMATION
`ansible-lint --profile production` and `yamllint` pass on all new content (52 files). Integration tests follow the `windows_ops_test_<role_name>` naming convention.