### PR TITLE
feat: add windows_manage_user_experience role

### DIFF
--- a/changelogs/fragments/add-windows-manage-user-experience.yml
+++ b/changelogs/fragments/add-windows-manage-user-experience.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - "windows_manage_user_experience - new role for configuring Windows user experience settings such as Server Manager auto-launch, network location wizard, and Welcome Screen behavior
-    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+    (https://github.com/redhat-cop/infra.windows_ops/pull/82)."

--- a/changelogs/fragments/add-windows-manage-user-experience.yml
+++ b/changelogs/fragments/add-windows-manage-user-experience.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "windows_manage_user_experience - new role for configuring Windows user experience settings such as Server Manager auto-launch, network location wizard, and Welcome Screen behavior
+    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/extensions/patterns/manage_user_experience/exec_env/README.md
+++ b/extensions/patterns/manage_user_experience/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_user_experience/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_user_experience/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_user_experience/exec_env/requirements.yml
+++ b/extensions/patterns/manage_user_experience/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_user_experience/playbooks/run_manage_user_experience.yml
+++ b/extensions/patterns/manage_user_experience/playbooks/run_manage_user_experience.yml
@@ -1,0 +1,13 @@
+---
+- name: Manage Windows User Experience Settings
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Configure user experience
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_experience
+      vars:
+        windows_manage_user_experience_server_manager_at_logon: "{{ server_manager_at_logon | default(true) | bool }}"  # Set by survey
+        windows_manage_user_experience_network_location_wizard: "{{ network_location_wizard | default(false) | bool }}"  # Set by survey
+        windows_manage_user_experience_show_last_user_name: "{{ show_last_user_name | default(true) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_user_experience/setup.yml
+++ b/extensions/patterns/manage_user_experience/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_user_experience_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_user_experience
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of Windows user experience settings.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of user experience configurations.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage User Experience
+    description: >
+      This job template manages Windows user experience settings, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_user_experience_pattern
+      - run_manage_user_experience
+    playbook: "extensions/patterns/manage_user_experience/playbooks/run_manage_user_experience.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_user_experience.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_user_experience/template_surveys/manage_user_experience.yml
+++ b/extensions/patterns/manage_user_experience/template_surveys/manage_user_experience.yml
@@ -1,0 +1,33 @@
+---
+name: "Manage User Experience Survey"
+description: "Survey to configure Windows user experience options"
+spec:
+  - question_name: "Open Server Manager at Logon"
+    question_description: "Open Server Manager automatically at logon"
+    required: true
+    variable: "server_manager_at_logon"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Network Location Wizard"
+    question_description: "Enable or disable the new network location wizard"
+    required: true
+    variable: "network_location_wizard"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Show Last User Name"
+    question_description: "Show or hide the last user name on the Welcome Screen"
+    required: true
+    variable: "show_last_user_name"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"

--- a/roles/windows_manage_user_experience/README.md
+++ b/roles/windows_manage_user_experience/README.md
@@ -1,0 +1,33 @@
+# windows_manage_user_experience
+
+Configure Windows user experience settings such as Server Manager auto-launch, network location wizard, and Welcome Screen behavior.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_user_experience_server_manager_at_logon` | bool | `true` | Open Server Manager automatically at logon |
+| `windows_manage_user_experience_network_location_wizard` | bool | `false` | Enable or disable the new network location wizard |
+| `windows_manage_user_experience_show_last_user_name` | bool | `true` | Show or hide the last user name on the Welcome Screen |
+
+## Example Playbook
+
+```yaml
+- name: Configure user experience
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_user_experience
+      vars:
+        windows_manage_user_experience_server_manager_at_logon: false
+        windows_manage_user_experience_network_location_wizard: false
+        windows_manage_user_experience_show_last_user_name: false
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_user_experience/defaults/main.yml
+++ b/roles/windows_manage_user_experience/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Open Server Manager automatically at logon
+windows_manage_user_experience_server_manager_at_logon: true
+
+# Enable or disable the new network location wizard
+windows_manage_user_experience_network_location_wizard: false
+
+# Show or hide the last user name on the Welcome Screen
+windows_manage_user_experience_show_last_user_name: true

--- a/roles/windows_manage_user_experience/meta/argument_specs.yml
+++ b/roles/windows_manage_user_experience/meta/argument_specs.yml
@@ -1,0 +1,28 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Configure Windows user experience settings.
+    description:
+      - Configure interactive logon and desktop experience settings on Windows hosts.
+      - Manages Server Manager auto-launch, the new network location wizard, and
+        whether the last user name is shown on the Welcome Screen.
+    options:
+      windows_manage_user_experience_server_manager_at_logon:
+        type: bool
+        description:
+          - Open Server Manager automatically at logon.
+          - Set to C(false) to prevent Server Manager from launching at logon.
+        default: true
+      windows_manage_user_experience_network_location_wizard:
+        type: bool
+        description:
+          - Enable or disable the new network location wizard.
+          - When C(false), the wizard is suppressed for new networks.
+        default: false
+      windows_manage_user_experience_show_last_user_name:
+        type: bool
+        description:
+          - Show or hide the last user name on the Welcome Screen.
+          - Set to C(false) to hide the last signed-in user name.
+        default: true

--- a/roles/windows_manage_user_experience/meta/main.yml
+++ b/roles/windows_manage_user_experience/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: windows_manage_user_experience
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Configure Windows user experience settings such as Server Manager auto-launch, network location wizard, and Welcome Screen behavior.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - configuration
+dependencies: []

--- a/roles/windows_manage_user_experience/tasks/main.yml
+++ b/roles/windows_manage_user_experience/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: Configure Server Manager at logon
+  ansible.windows.win_regedit:
+    path: HKLM:\SOFTWARE\Microsoft\ServerManager
+    name: DoNotOpenServerManagerAtLogon
+    type: dword
+    data: "{{ 0 if windows_manage_user_experience_server_manager_at_logon | bool else 1 }}"
+
+- name: Configure new network location wizard
+  ansible.windows.win_regedit:
+    path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+    state: "{{ 'absent' if windows_manage_user_experience_network_location_wizard | bool else 'present' }}"
+
+- name: Configure showing last user name on Welcome Screen
+  ansible.windows.win_regedit:
+    path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+    name: DontDisplayLastUserName
+    type: dword
+    data: "{{ 0 if windows_manage_user_experience_show_last_user_name | bool else 1 }}"

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_experience/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_experience/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_experience/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_experience/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Test toggles the three user experience registry settings across two states
+# and verifies idempotency, then restores the original values.

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_experience/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_experience/tasks/main.yml
@@ -1,0 +1,147 @@
+---
+- name: Test user experience configuration
+  block:
+    - name: Capture original Server Manager at logon setting
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+      register: windows_manage_user_experience__original_srvmgr
+
+    - name: Capture original network location wizard key
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+      register: windows_manage_user_experience__original_netwiz
+
+    - name: Capture original last user name setting
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: DontDisplayLastUserName
+      register: windows_manage_user_experience__original_lastuser
+
+    # -- State A: all settings disabled --
+    - name: Configure user experience (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_experience
+      vars:
+        windows_manage_user_experience_server_manager_at_logon: false
+        windows_manage_user_experience_network_location_wizard: false
+        windows_manage_user_experience_show_last_user_name: false
+
+    - name: Verify Server Manager setting after state A
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+      register: windows_manage_user_experience__verify_srvmgr_a
+
+    - name: Verify network location wizard key after state A
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+      register: windows_manage_user_experience__verify_netwiz_a
+
+    - name: Verify last user name setting after state A
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: DontDisplayLastUserName
+      register: windows_manage_user_experience__verify_lastuser_a
+
+    - name: Assert state A applied
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_experience__verify_srvmgr_a.value == 1
+          - windows_manage_user_experience__verify_netwiz_a.exists
+          - windows_manage_user_experience__verify_lastuser_a.value == 1
+        fail_msg: "State A settings were not applied correctly"
+
+    # -- Idempotency --
+    - name: Run role again to verify idempotency (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_experience
+      vars:
+        windows_manage_user_experience_server_manager_at_logon: false
+        windows_manage_user_experience_network_location_wizard: false
+        windows_manage_user_experience_show_last_user_name: false
+      register: windows_manage_user_experience__idempotent
+
+    - name: Verify settings unchanged after idempotent re-run
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+      register: windows_manage_user_experience__verify_idempotent
+
+    - name: Assert state unchanged after idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_experience__verify_idempotent.value == 1
+        fail_msg: "Role is not idempotent - registry values changed on re-run"
+
+    # -- State B: all settings enabled --
+    - name: Configure user experience (state B)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_experience
+      vars:
+        windows_manage_user_experience_server_manager_at_logon: true
+        windows_manage_user_experience_network_location_wizard: true
+        windows_manage_user_experience_show_last_user_name: true
+
+    - name: Verify Server Manager setting after state B
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+      register: windows_manage_user_experience__verify_srvmgr_b
+
+    - name: Verify network location wizard key after state B
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+      register: windows_manage_user_experience__verify_netwiz_b
+
+    - name: Verify last user name setting after state B
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: DontDisplayLastUserName
+      register: windows_manage_user_experience__verify_lastuser_b
+
+    - name: Assert state B applied
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_experience__verify_srvmgr_b.value == 0
+          - not windows_manage_user_experience__verify_netwiz_b.exists
+          - windows_manage_user_experience__verify_lastuser_b.value == 0
+        fail_msg: "State B settings were not applied correctly"
+
+  always:
+    - name: Restore original Server Manager setting
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+        type: dword
+        data: "{{ windows_manage_user_experience__original_srvmgr.value }}"
+        state: present
+      when: windows_manage_user_experience__original_srvmgr.exists
+
+    - name: Remove Server Manager setting if it did not exist originally
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\ServerManager
+        name: DoNotOpenServerManagerAtLogon
+        state: absent
+      when: not windows_manage_user_experience__original_srvmgr.exists
+
+    - name: Restore original network location wizard key
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+        state: "{{ 'present' if windows_manage_user_experience__original_netwiz.exists else 'absent' }}"
+
+    - name: Restore original last user name setting
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: DontDisplayLastUserName
+        type: dword
+        data: "{{ windows_manage_user_experience__original_lastuser.value }}"
+        state: present
+      when: windows_manage_user_experience__original_lastuser.exists
+
+    - name: Remove last user name setting if it did not exist originally
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+        name: DontDisplayLastUserName
+        state: absent
+      when: not windows_manage_user_experience__original_lastuser.exists


### PR DESCRIPTION
##### SUMMARY

Part of the Windows content migration (ACA-2792). Adds the `windows_manage_user_experience` role, migrated from the upstream `user_experience` role in `myllynen/windows-ansible-roles`.

The role configures interactive logon and desktop experience settings via the registry: Server Manager auto-launch, the new network location wizard, and whether the last user name is shown on the Welcome Screen.

Ships with `meta/argument_specs.yml`, README, an AAP pattern (setup/playbook/survey/exec-env), and a two-state idempotent integration test (`windows_ops_test_windows_manage_user_experience`) with capture/restore, correctly handling `NewNetworkWindowOff` as a key-existence toggle.

##### ISSUE TYPE
New Module Pull Request

##### COMPONENT NAME
windows_manage_user_experience

##### ADDITIONAL INFORMATION
`ansible-lint --profile production` and `yamllint` pass on all new content.