### PR TITLE
feat: add windows_manage_user_settings role

### DIFF
--- a/changelogs/fragments/add-windows-manage-user-settings.yml
+++ b/changelogs/fragments/add-windows-manage-user-settings.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "windows_manage_user_settings - new role for applying per-user registry settings across existing and logged-in Windows user profiles
+    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-user-settings.yml
+++ b/changelogs/fragments/add-windows-manage-user-settings.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - "windows_manage_user_settings - new role for applying per-user registry settings across existing and logged-in Windows user profiles
-    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+    (https://github.com/redhat-cop/infra.windows_ops/pull/83)."

--- a/extensions/patterns/manage_user_settings/exec_env/README.md
+++ b/extensions/patterns/manage_user_settings/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_user_settings/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_user_settings/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_user_settings/exec_env/requirements.yml
+++ b/extensions/patterns/manage_user_settings/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_user_settings/playbooks/run_manage_user_settings.yml
+++ b/extensions/patterns/manage_user_settings/playbooks/run_manage_user_settings.yml
@@ -1,0 +1,14 @@
+---
+- name: Manage Windows User Settings
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Apply user settings
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_settings
+      vars:
+        windows_manage_user_settings_apply_to_logged_in_users: "{{ user_settings_apply_to_logged_in_users | default(true) | bool }}"  # Set by survey
+        # windows_manage_user_settings_registry is a list of dicts and is not
+        # survey-friendly; provide it via extra variables on the job template.
+        windows_manage_user_settings_registry: "{{ user_settings_registry | default([]) }}"
+...

--- a/extensions/patterns/manage_user_settings/setup.yml
+++ b/extensions/patterns/manage_user_settings/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_user_settings_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_user_settings
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of user settings.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of per-user registry settings.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage User Settings
+    description: >
+      This job template applies per-user registry settings, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_user_settings_pattern
+      - run_manage_user_settings
+    playbook: "extensions/patterns/manage_user_settings/playbooks/run_manage_user_settings.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_user_settings.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_user_settings/template_surveys/manage_user_settings.yml
+++ b/extensions/patterns/manage_user_settings/template_surveys/manage_user_settings.yml
@@ -1,0 +1,15 @@
+---
+name: "Manage User Settings Survey"
+description: "Survey to configure how per-user registry settings are applied"
+spec:
+  - question_name: "Apply to Logged In Users"
+    question_description: "Apply settings to users who are currently logged in (via become)"
+    required: true
+    variable: "user_settings_apply_to_logged_in_users"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+  # NOTE: windows_manage_user_settings_registry is a list of dicts and is not
+  # survey-friendly. Provide it via extra variables on the job template.

--- a/roles/windows_manage_user_settings/README.md
+++ b/roles/windows_manage_user_settings/README.md
@@ -1,0 +1,60 @@
+# windows_manage_user_settings
+
+Apply per-user registry settings across existing and logged-in Windows user profiles.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_user_settings_apply_to_logged_in_users` | bool | `true` | Apply settings to currently logged-in users via `become` |
+| `windows_manage_user_settings_registry` | list(dict) | `[]` | Registry settings to apply per user profile |
+
+Each `windows_manage_user_settings_registry` item supports:
+
+| Key | Required | Description |
+|---|---|---|
+| `setting` | yes | Human-readable label for the setting |
+| `path` | yes | Registry path (typically under `HKCU:`) |
+| `name` | no | Value name |
+| `type` | no | Value type (e.g. `DWord`, `String`) |
+| `data` | no | Value data |
+| `state` | no | `present` (default) or `absent` |
+
+## Example Playbook
+
+```yaml
+- name: Apply user settings
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_user_settings
+      vars:
+        windows_manage_user_settings_apply_to_logged_in_users: true
+        windows_manage_user_settings_registry:
+          - setting: Minimize Visual Effects for Performance
+            path: HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects
+            name: VisualFXSetting
+            type: DWord
+            data: 2
+          - setting: Disable Taskbar Animations
+            path: HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+            name: TaskbarAnimations
+            type: DWord
+            data: 0
+```
+
+## How it works
+
+Each `HKCU:` setting is applied to every existing user profile by loading that
+profile's `NTUSER.DAT` hive. For users who are currently logged in the hive is
+locked; when `windows_manage_user_settings_apply_to_logged_in_users` is `true`
+those settings are re-applied via `become` in the user's own context. The
+connecting Ansible user's own profile is intentionally excluded.
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_user_settings/defaults/main.yml
+++ b/roles/windows_manage_user_settings/defaults/main.yml
@@ -1,0 +1,20 @@
+---
+# Apply settings to users who are currently logged in (their hive is locked).
+# Some settings may only take effect after the user logs in again.
+windows_manage_user_settings_apply_to_logged_in_users: true
+
+# User registry settings to apply with ansible.windows.win_regedit.
+# Each item: setting (label), path, and optionally name, type, data, state.
+# Paths are typically under HKCU: as they are applied per user profile.
+windows_manage_user_settings_registry: []
+#  - setting: Minimize Visual Effects for Performance
+#    path: HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VisualEffects
+#    name: VisualFXSetting
+#    type: DWord
+#    data: 2
+#
+#  - setting: Disable Taskbar Animations
+#    path: HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Advanced
+#    name: TaskbarAnimations
+#    type: DWord
+#    data: 0

--- a/roles/windows_manage_user_settings/meta/argument_specs.yml
+++ b/roles/windows_manage_user_settings/meta/argument_specs.yml
@@ -1,0 +1,28 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Apply per-user Windows registry settings.
+    description:
+      - Apply registry settings to existing user profiles by loading each
+        profile's C(NTUSER.DAT) hive.
+      - For users who are currently logged in (whose hive is locked), settings
+        are applied in the user's own context via C(become).
+      - The connecting Ansible user's own profile is intentionally excluded.
+    options:
+      windows_manage_user_settings_apply_to_logged_in_users:
+        type: bool
+        description:
+          - Apply settings to users who are currently logged in by using C(become).
+          - When C(false), profiles whose hive is locked are skipped instead of
+            failing.
+        default: true
+      windows_manage_user_settings_registry:
+        type: list
+        elements: dict
+        description:
+          - List of registry settings to apply to each user profile.
+          - Each item must include C(setting) (a human-readable label) and C(path).
+          - "Optional keys per item: C(name), C(type), C(data), and C(state)."
+          - Paths are typically under C(HKCU:) as they are applied per user profile.
+        default: []

--- a/roles/windows_manage_user_settings/meta/main.yml
+++ b/roles/windows_manage_user_settings/meta/main.yml
@@ -1,0 +1,18 @@
+---
+galaxy_info:
+  role_name: windows_manage_user_settings
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Apply per-user registry settings across existing and logged-in Windows user profiles.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - configuration
+dependencies: []

--- a/roles/windows_manage_user_settings/tasks/main.yml
+++ b/roles/windows_manage_user_settings/tasks/main.yml
@@ -1,0 +1,79 @@
+---
+- name: Check connecting user
+  vars:
+    windows_manage_user_settings__conn_user: "{{ 'ansible_' + ansible_connection + '_user' }}"
+    windows_manage_user_settings__remote_user: "{{ lookup('vars', windows_manage_user_settings__conn_user, default='') | default(ansible_user, true) }}"
+  ansible.builtin.set_fact:
+    windows_manage_user_settings__ansible_user: "{{ windows_manage_user_settings__remote_user | default(lookup('env', 'USER'), true) }}"
+
+# There is no native ansible.windows/community.windows module that enumerates all
+# user profiles with SID-to-name translation, so win_powershell is used here.
+- name: Get list of user profiles
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $userProfiles = @()
+      $excludeSIDs = '^S-1-5-(18|19|20)$|^S-1-5-21-\d+-\d+-\d+-(501|503|504)$'
+      $localProfiles = Get-CimInstance -ClassName Win32_UserProfile | Where-Object {
+        -not $_.Special -and $_.SID -notmatch $excludeSIDs
+      } | ForEach-Object {
+        $profileObject = $_
+        try {
+          $userName = ([System.Security.Principal.SecurityIdentifier]$profileObject.SID).Translate([System.Security.Principal.NTAccount]).Value
+        }
+        catch {
+          $userName = $profileObject.SID
+        }
+        if ($userName -notmatch '\\{{ windows_manage_user_settings__ansible_user }}$') {
+          [PSCustomObject]@{
+            UserName  = $userName
+            LocalPath = $profileObject.LocalPath
+          }
+        }
+      } | Where-Object { $_ -ne $null }
+      $userProfiles += $localProfiles
+      $defaultProfile = [PSCustomObject]@{
+        UserName  = 'Default Profile'
+        LocalPath = 'C:\Users\Default'
+      }
+      $userProfiles += $defaultProfile
+      $Ansible.Result = $userProfiles
+  register: windows_manage_user_settings__profiles
+  changed_when: false
+  when: windows_manage_user_settings_registry | length > 0
+
+- name: Configure user registry settings
+  ansible.windows.win_regedit:
+    hive: "{{ item[0].LocalPath }}\\NTUSER.DAT"
+    path: "{{ item[1].path }}"
+    name: "{{ item[1].name | default(omit) }}"
+    type: "{{ item[1].type | default(omit) }}"
+    data: "{{ item[1].data | default(omit) }}"
+    state: "{{ item[1].state | default(omit) }}"
+  register: windows_manage_user_settings__update
+  failed_when:
+    - windows_manage_user_settings__update.msg is defined
+    - windows_manage_user_settings_apply_to_logged_in_users | bool or
+      'used by another process' not in windows_manage_user_settings__update.msg
+  ignore_errors: "{{ windows_manage_user_settings_apply_to_logged_in_users | bool }}"
+  loop: "{{ windows_manage_user_settings__profiles.result | product(windows_manage_user_settings_registry) }}"
+  loop_control:
+    label: "{{ item[0].UserName }} - {{ item[1].setting }}"
+  when: windows_manage_user_settings_registry | length > 0
+
+- name: Apply settings to logged in users
+  vars:
+    windows_manage_user_settings__failed_users: "{{ windows_manage_user_settings__update.results | selectattr('failed', 'equalto', true) | map(attribute='item.0') | unique }}"
+  become: true
+  become_user: "{{ item[0].UserName }}"
+  ansible.windows.win_regedit:
+    path: "{{ item[1].path }}"
+    name: "{{ item[1].name | default(omit) }}"
+    type: "{{ item[1].type | default(omit) }}"
+    data: "{{ item[1].data | default(omit) }}"
+    state: "{{ item[1].state | default(omit) }}"
+  loop: "{{ windows_manage_user_settings__failed_users | product(windows_manage_user_settings_registry) }}"
+  loop_control:
+    label: "{{ item[0].UserName }} - {{ item[1].setting }}"
+  when: windows_manage_user_settings_registry | length > 0

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_settings/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_settings/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_settings/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_settings/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# The test applies a throwaway HKCU setting to the Default user profile and
+# verifies it by loading the profile hive with reg.exe. The role intentionally
+# excludes the connecting WinRM user's own profile, so the Default profile
+# (always included by the role) is used as the deterministic verification target.

--- a/tests/integration/targets/windows_ops_test_windows_manage_user_settings/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_user_settings/tasks/main.yml
@@ -1,0 +1,136 @@
+---
+- name: Test user settings configuration
+  vars:
+    windows_manage_user_settings__test_hive_key: 'HKLM\AnsibleUserSettingsTest'
+    windows_manage_user_settings__default_hive: 'C:\Users\Default\NTUSER.DAT'
+    windows_manage_user_settings__verify_path: 'HKLM:\AnsibleUserSettingsTest\SOFTWARE\_ansible_windows_ops_test'
+  block:
+    # -- State A: apply DWord = 1 to the Default profile --
+    - name: Apply user setting (state A - data 1)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_settings
+      vars:
+        windows_manage_user_settings_apply_to_logged_in_users: false
+        windows_manage_user_settings_registry:
+          - setting: Ansible test marker
+            path: 'HKCU:\SOFTWARE\_ansible_windows_ops_test'
+            name: UserSettingsTest
+            type: DWord
+            data: 1
+
+    - name: Load Default profile hive for verification (state A)
+      ansible.windows.win_command: >-
+        reg load {{ windows_manage_user_settings__test_hive_key }}
+        {{ windows_manage_user_settings__default_hive }}
+      changed_when: true
+
+    - name: Read applied value (state A)
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_user_settings__verify_path }}"
+        name: UserSettingsTest
+      register: windows_manage_user_settings__verify_a
+
+    - name: Unload Default profile hive (state A)
+      ansible.windows.win_command: >-
+        reg unload {{ windows_manage_user_settings__test_hive_key }}
+      changed_when: true
+
+    - name: Assert setting applied to Default profile (state A)
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_settings__verify_a.exists
+          - windows_manage_user_settings__verify_a.value == 1
+        fail_msg: "User setting was not applied to the Default profile"
+
+    # -- Idempotency: re-run state A --
+    - name: Apply user setting again (idempotency)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_settings
+      vars:
+        windows_manage_user_settings_apply_to_logged_in_users: false
+        windows_manage_user_settings_registry:
+          - setting: Ansible test marker
+            path: 'HKCU:\SOFTWARE\_ansible_windows_ops_test'
+            name: UserSettingsTest
+            type: DWord
+            data: 1
+
+    - name: Load Default profile hive for verification (idempotency)
+      ansible.windows.win_command: >-
+        reg load {{ windows_manage_user_settings__test_hive_key }}
+        {{ windows_manage_user_settings__default_hive }}
+      changed_when: true
+
+    - name: Read value after idempotent re-run
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_user_settings__verify_path }}"
+        name: UserSettingsTest
+      register: windows_manage_user_settings__verify_idem
+
+    - name: Unload Default profile hive (idempotency)
+      ansible.windows.win_command: >-
+        reg unload {{ windows_manage_user_settings__test_hive_key }}
+      changed_when: true
+
+    - name: Assert value unchanged after idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_settings__verify_idem.value == 1
+        fail_msg: "User setting changed on idempotent re-run"
+
+    # -- State B: apply DWord = 0 --
+    - name: Apply user setting (state B - data 0)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_user_settings
+      vars:
+        windows_manage_user_settings_apply_to_logged_in_users: false
+        windows_manage_user_settings_registry:
+          - setting: Ansible test marker
+            path: 'HKCU:\SOFTWARE\_ansible_windows_ops_test'
+            name: UserSettingsTest
+            type: DWord
+            data: 0
+
+    - name: Load Default profile hive for verification (state B)
+      ansible.windows.win_command: >-
+        reg load {{ windows_manage_user_settings__test_hive_key }}
+        {{ windows_manage_user_settings__default_hive }}
+      changed_when: true
+
+    - name: Read applied value (state B)
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_user_settings__verify_path }}"
+        name: UserSettingsTest
+      register: windows_manage_user_settings__verify_b
+
+    - name: Unload Default profile hive (state B)
+      ansible.windows.win_command: >-
+        reg unload {{ windows_manage_user_settings__test_hive_key }}
+      changed_when: true
+
+    - name: Assert setting updated in Default profile (state B)
+      ansible.builtin.assert:
+        that:
+          - windows_manage_user_settings__verify_b.value == 0
+        fail_msg: "User setting was not updated to 0 in the Default profile"
+
+  always:
+    # Remove the throwaway test key from the Default profile hive.
+    - name: Load Default profile hive for cleanup
+      ansible.windows.win_command: >-
+        reg load {{ windows_manage_user_settings__test_hive_key }}
+        {{ windows_manage_user_settings__default_hive }}
+      changed_when: true
+      failed_when: false
+
+    - name: Remove test key from Default profile
+      ansible.windows.win_command: >-
+        reg delete {{ windows_manage_user_settings__test_hive_key }}\SOFTWARE\_ansible_windows_ops_test /f
+      changed_when: true
+      failed_when: false
+
+    - name: Unload Default profile hive after cleanup
+      ansible.windows.win_command: >-
+        reg unload {{ windows_manage_user_settings__test_hive_key }}
+      changed_when: true
+      failed_when: false


### PR DESCRIPTION
##### SUMMARY

Part of the Windows content migration (ACA-2792). Adds the `windows_manage_user_settings` role, migrated from the upstream `user_settings` role in `myllynen/windows-ansible-roles`.

The role applies per-user registry settings across existing profiles by loading each profile's `NTUSER.DAT` hive, with a `become` fallback for logged-in users whose hive is locked. The connecting Ansible user's own profile is intentionally excluded.

Migration standards applied:
- Internal implementation variables use the `windows_manage_user_settings__<var>` (double-underscore) form; public variables keep the single-underscore interface.
- Defensive empty/null input filtering removed in favor of argument spec validation; the `| length > 0` skip-enumeration optimization is retained.

A single `win_powershell` task is retained to enumerate user profiles with SID-to-name translation, as no native `ansible.windows`/`community.windows` module covers this.

Ships with `meta/argument_specs.yml`, README, an AAP pattern (setup/playbook/survey/exec-env), and a two-state idempotent integration test (`windows_ops_test_windows_manage_user_settings`) that applies to the Default profile and verifies via `reg load`/`win_reg_stat` with hive cleanup.

##### ISSUE TYPE
New Module Pull Request

##### COMPONENT NAME
windows_manage_user_settings

##### ADDITIONAL INFORMATION
`ansible-lint --profile production` and `yamllint` pass on all new content.