### PR TITLE
feat(windows_manage_file_acl): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-file-acl.yml
+++ b/changelogs/fragments/add-windows-manage-file-acl.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - windows_manage_file_acl - new role to manage Windows file and directory ACLs, ownership, and ACL inheritance (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX).

--- a/changelogs/fragments/add-windows-manage-file-acl.yml
+++ b/changelogs/fragments/add-windows-manage-file-acl.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - windows_manage_file_acl - new role to manage Windows file and directory ACLs, ownership, and ACL inheritance (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX).
+  - windows_manage_file_acl - new role to manage Windows file and directory ACLs, ownership, and ACL inheritance (https://github.com/redhat-cop/infra.windows_ops/pull/84).

--- a/extensions/patterns/manage_file_acl/exec_env/README.md
+++ b/extensions/patterns/manage_file_acl/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_file_acl/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_file_acl/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_file_acl/exec_env/requirements.yml
+++ b/extensions/patterns/manage_file_acl/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_file_acl/playbooks/run_manage_file_acl.yml
+++ b/extensions/patterns/manage_file_acl/playbooks/run_manage_file_acl.yml
@@ -1,0 +1,12 @@
+---
+- name: Manage Windows file and directory ACLs
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Manage file ACLs
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_acl
+      vars:
+        # Survey values arrive as YAML strings; parse them into lists.
+        windows_manage_file_acl_acls: "{{ (file_acl_acls | default('[]')) | from_yaml }}"
+        windows_manage_file_acl_inheritance: "{{ (file_acl_inheritance | default('[]')) | from_yaml }}"

--- a/extensions/patterns/manage_file_acl/setup.yml
+++ b/extensions/patterns/manage_file_acl/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_file_acl_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_file_acl
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of file ACLs.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of file and directory access control.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage File ACL
+    description: >
+      This job template manages file and directory ACLs, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_file_acl_pattern
+      - run_manage_file_acl
+    playbook: "extensions/patterns/manage_file_acl/playbooks/run_manage_file_acl.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_file_acl.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_file_acl/template_surveys/manage_file_acl.yml
+++ b/extensions/patterns/manage_file_acl/template_surveys/manage_file_acl.yml
@@ -1,0 +1,25 @@
+---
+name: "Manage File ACL Survey"
+description: "Survey to configure Windows file and directory ACLs."
+spec:
+  - question_name: "ACL Entries (YAML)"
+    question_description: >-
+      YAML list of ACL entries. Each item requires path, user, type and rights;
+      optional keys: state, follow, inherit, propagation, owner, recurse.
+    required: false
+    variable: "file_acl_acls"
+    type: "textarea"
+    default: |-
+      - path: C:\Temp\log.txt
+        user: Guests
+        type: deny
+        rights: Write,Modify
+        state: present
+  - question_name: "ACL Inheritance Rules (YAML)"
+    question_description: >-
+      YAML list of ACL inheritance rules. Each item requires path;
+      optional keys: state, reorganize.
+    required: false
+    variable: "file_acl_inheritance"
+    type: "textarea"
+    default: "[]"

--- a/roles/windows_manage_file_acl/README.md
+++ b/roles/windows_manage_file_acl/README.md
@@ -1,0 +1,43 @@
+# windows_manage_file_acl
+
+Manage Windows file and directory ACLs, ownership, and ACL inheritance.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_file_acl_acls` | list(dict) | `[]` | ACLs to apply. Each item: `path`, `user`, `type`, `rights` (required); optional `state`, `follow`, `inherit`, `propagation`, `owner`, `recurse` |
+| `windows_manage_file_acl_inheritance` | list(dict) | `[]` | ACL inheritance rules. Each item: `path` (required); optional `state`, `reorganize` |
+
+When an item in `windows_manage_file_acl_acls` includes `owner`, the path owner is set with
+`ansible.windows.win_owner` (with optional `recurse`).
+
+## Example Playbook
+
+```yaml
+- name: Manage file ACLs
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_file_acl
+      vars:
+        windows_manage_file_acl_acls:
+          - path: C:\Temp\log.txt
+            owner: BUILTIN\Administrators
+            user: Guests
+            type: deny
+            rights: Write,Modify
+            state: present
+        windows_manage_file_acl_inheritance:
+          - path: C:\Temp
+            state: absent
+            reorganize: true
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_file_acl/defaults/main.yml
+++ b/roles/windows_manage_file_acl/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# List of ACLs to apply to files and directories.
+# Uses ansible.windows.win_acl (and ansible.windows.win_owner when owner is set).
+# Mandatory keys per item: path, user, type, rights
+windows_manage_file_acl_acls: []
+#  - path: C:\Temp\log.txt
+#    #owner: BUILTIN\Administrator
+#    user: testuser
+#    type: deny
+#    rights: Read,Write,Modify,FullControl,Delete
+#    state: present
+
+# List of ACL inheritance rules to apply to paths.
+# Uses ansible.windows.win_acl_inheritance.
+# Mandatory keys per item: path
+windows_manage_file_acl_inheritance: []
+#  - path: C:\apache
+#    state: present
+#    reorganize: true

--- a/roles/windows_manage_file_acl/meta/argument_specs.yml
+++ b/roles/windows_manage_file_acl/meta/argument_specs.yml
@@ -1,0 +1,28 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Manage Windows file and directory ACLs.
+    description:
+      - Apply access control entries to files and directories using C(ansible.windows.win_acl).
+      - Optionally set the path owner using C(ansible.windows.win_owner).
+      - Configure ACL inheritance using C(ansible.windows.win_acl_inheritance).
+    options:
+      windows_manage_file_acl_acls:
+        type: list
+        elements: dict
+        description:
+          - List of ACLs to apply to files and directories.
+          - Each item must include C(path), C(user), C(type), and C(rights).
+          - "Optional keys per item: C(state), C(follow), C(inherit), C(propagation)."
+          - When C(owner) is set on an item, the path owner is updated with C(win_owner);
+            C(recurse) may also be set to apply ownership recursively.
+        default: []
+      windows_manage_file_acl_inheritance:
+        type: list
+        elements: dict
+        description:
+          - List of ACL inheritance rules to apply to paths.
+          - Each item must include C(path).
+          - "Optional keys per item: C(state) and C(reorganize)."
+        default: []

--- a/roles/windows_manage_file_acl/meta/main.yml
+++ b/roles/windows_manage_file_acl/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_file_acl
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Manage Windows file and directory ACLs, ownership, and ACL inheritance.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - acl
+    - configuration
+dependencies: []

--- a/roles/windows_manage_file_acl/tasks/main.yml
+++ b/roles/windows_manage_file_acl/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: Configure ACLs
+  ansible.windows.win_acl:
+    path: "{{ item.path }}"
+    user: "{{ item.user }}"
+    type: "{{ item.type }}"
+    rights: "{{ item.rights }}"
+    state: "{{ item.state | default(omit) }}"
+    follow: "{{ item.follow | default(omit) }}"
+    inherit: "{{ item.inherit | default(omit) }}"
+    propagation: "{{ item.propagation | default(omit) }}"
+  register: windows_manage_file_acl__acl_files
+  loop: "{{ windows_manage_file_acl_acls }}"
+  loop_control:
+    label: "{{ item.path }}"
+
+- name: Update path owner
+  ansible.windows.win_owner:
+    path: "{{ item.path }}"
+    user: "{{ item.owner }}"
+    recurse: "{{ item.recurse | default(omit) }}"
+  loop: "{{ windows_manage_file_acl_acls | selectattr('owner', 'defined') }}"
+  loop_control:
+    label: "{{ item.path }}"
+
+- name: Configure ACL inheritance
+  ansible.windows.win_acl_inheritance:
+    path: "{{ item.path }}"
+    state: "{{ item.state | default(omit) }}"
+    reorganize: "{{ item.reorganize | default(omit) }}"
+  register: windows_manage_file_acl__inheritance_files
+  loop: "{{ windows_manage_file_acl_inheritance }}"
+  loop_control:
+    label: "{{ item.path }}"

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_acl/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_acl/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_acl/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_acl/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Throwaway test artifacts created under the Windows temp directory.
+# The test applies an ACL for the built-in Guests account (a low-risk,
+# always-present principal) to a temporary file, then cleans up.
+windows_ops_test_file_acl_dir: C:\Windows\Temp\windows_manage_file_acl_test
+windows_ops_test_file_acl_file: C:\Windows\Temp\windows_manage_file_acl_test\acl_target.txt
+windows_ops_test_file_acl_user: Guests

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_acl/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_acl/tasks/main.yml
@@ -1,0 +1,123 @@
+---
+- name: Test windows_manage_file_acl
+  block:
+    - name: Create test directory
+      ansible.windows.win_file:
+        path: "{{ windows_ops_test_file_acl_dir }}"
+        state: directory
+
+    - name: Create test target file
+      ansible.windows.win_copy:
+        dest: "{{ windows_ops_test_file_acl_file }}"
+        content: "windows_manage_file_acl integration test"
+
+    # -- State A: apply a deny ACL for the Guests account --
+    - name: Apply ACL (state A - deny present)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_acl
+      vars:
+        windows_manage_file_acl_acls:
+          - path: "{{ windows_ops_test_file_acl_file }}"
+            user: "{{ windows_ops_test_file_acl_user }}"
+            type: deny
+            rights: Write,Modify
+            state: present
+        windows_manage_file_acl_inheritance:
+          - path: "{{ windows_ops_test_file_acl_file }}"
+            state: absent
+            reorganize: true
+
+    - name: Verify ACL is present (check mode reports no change)
+      ansible.windows.win_acl:
+        path: "{{ windows_ops_test_file_acl_file }}"
+        user: "{{ windows_ops_test_file_acl_user }}"
+        type: deny
+        rights: Write,Modify
+        state: present
+      check_mode: true
+      register: windows_ops_test_file_acl_verify_a
+
+    - name: Assert ACL was applied in state A
+      ansible.builtin.assert:
+        that:
+          - not windows_ops_test_file_acl_verify_a.changed
+        fail_msg: "Deny ACL for {{ windows_ops_test_file_acl_user }} was not applied"
+
+    - name: Verify inheritance is disabled (check mode reports no change)
+      ansible.windows.win_acl_inheritance:
+        path: "{{ windows_ops_test_file_acl_file }}"
+        state: absent
+      check_mode: true
+      register: windows_ops_test_file_acl_verify_inherit_a
+
+    - name: Assert inheritance was disabled in state A
+      ansible.builtin.assert:
+        that:
+          - not windows_ops_test_file_acl_verify_inherit_a.changed
+        fail_msg: "ACL inheritance was not disabled"
+
+    # -- Idempotency: re-run the role with the same state --
+    - name: Apply ACL again (idempotency check)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_acl
+      vars:
+        windows_manage_file_acl_acls:
+          - path: "{{ windows_ops_test_file_acl_file }}"
+            user: "{{ windows_ops_test_file_acl_user }}"
+            type: deny
+            rights: Write,Modify
+            state: present
+        windows_manage_file_acl_inheritance:
+          - path: "{{ windows_ops_test_file_acl_file }}"
+            state: absent
+            reorganize: true
+
+    - name: Verify ACL still present after idempotent re-run
+      ansible.windows.win_acl:
+        path: "{{ windows_ops_test_file_acl_file }}"
+        user: "{{ windows_ops_test_file_acl_user }}"
+        type: deny
+        rights: Write,Modify
+        state: present
+      check_mode: true
+      register: windows_ops_test_file_acl_verify_idempotent
+
+    - name: Assert role is idempotent
+      ansible.builtin.assert:
+        that:
+          - not windows_ops_test_file_acl_verify_idempotent.changed
+        fail_msg: "Role is not idempotent - ACL changed on re-run"
+
+    # -- State B: remove the deny ACL --
+    - name: Remove ACL (state B - deny absent)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_acl
+      vars:
+        windows_manage_file_acl_acls:
+          - path: "{{ windows_ops_test_file_acl_file }}"
+            user: "{{ windows_ops_test_file_acl_user }}"
+            type: deny
+            rights: Write,Modify
+            state: absent
+
+    - name: Verify ACL is absent (check mode reports no change)
+      ansible.windows.win_acl:
+        path: "{{ windows_ops_test_file_acl_file }}"
+        user: "{{ windows_ops_test_file_acl_user }}"
+        type: deny
+        rights: Write,Modify
+        state: absent
+      check_mode: true
+      register: windows_ops_test_file_acl_verify_b
+
+    - name: Assert ACL was removed in state B
+      ansible.builtin.assert:
+        that:
+          - not windows_ops_test_file_acl_verify_b.changed
+        fail_msg: "Deny ACL for {{ windows_ops_test_file_acl_user }} was not removed"
+
+  always:
+    - name: Remove test directory
+      ansible.windows.win_file:
+        path: "{{ windows_ops_test_file_acl_dir }}"
+        state: absent


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_file_acl` role, migrated from the upstream `files_acl` role in myllynen/windows-ansible-roles. Manages Windows file and directory ACL entries, ownership, and inheritance via `ansible.windows.win_acl`, `win_owner`, and `win_acl_inheritance`.

Part of the ACA-2792 Windows content migration (Batch 5 — Files/Registry). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_file_acl`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_file_acl

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_file_acl_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_file_acl__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. `ansible-lint --profile production` and `yamllint` pass clean.