### PR TITLE
feat(windows_manage_file_copy): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-file-copy.yml
+++ b/changelogs/fragments/add-windows-manage-file-copy.yml
@@ -2,4 +2,4 @@
 minor_changes:
   - windows_manage_file_copy - new role to copy files and render templates to
     Windows hosts, optionally setting the destination path owner
-    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX).
+    (https://github.com/redhat-cop/infra.windows_ops/pull/85).

--- a/changelogs/fragments/add-windows-manage-file-copy.yml
+++ b/changelogs/fragments/add-windows-manage-file-copy.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - windows_manage_file_copy - new role to copy files and render templates to
+    Windows hosts, optionally setting the destination path owner
+    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX).

--- a/extensions/patterns/manage_file_copy/exec_env/README.md
+++ b/extensions/patterns/manage_file_copy/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_file_copy/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_file_copy/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_file_copy/exec_env/requirements.yml
+++ b/extensions/patterns/manage_file_copy/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_file_copy/playbooks/run_manage_file_copy.yml
+++ b/extensions/patterns/manage_file_copy/playbooks/run_manage_file_copy.yml
@@ -1,0 +1,17 @@
+---
+- name: Manage Windows File Copy
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Copy files and templates
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_copy
+      vars:
+        # A single destination + content pair can be provided via the survey;
+        # full file/template lists are provided via extra_vars / the job template.
+        windows_manage_file_copy_files: >-
+          {{ (file_copy_files | default([]))
+             + ([{'dest': file_copy_dest, 'content': file_copy_content}]
+                if (file_copy_dest | default('')) | length > 0 else []) }}
+        windows_manage_file_copy_templates: "{{ file_copy_templates | default([]) }}"
+...

--- a/extensions/patterns/manage_file_copy/setup.yml
+++ b/extensions/patterns/manage_file_copy/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_file_copy_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_file_copy
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the copying of files and templates.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of file copy operations.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage File Copy
+    description: >
+      This job template copies files and renders templates, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_file_copy_pattern
+      - run_manage_file_copy
+    playbook: "extensions/patterns/manage_file_copy/playbooks/run_manage_file_copy.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_file_copy.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_file_copy/template_surveys/manage_file_copy.yml
+++ b/extensions/patterns/manage_file_copy/template_surveys/manage_file_copy.yml
@@ -1,0 +1,20 @@
+---
+name: "Manage File Copy Survey"
+description: "Survey to copy a file to a Windows host"
+spec:
+  - question_name: "Destination Path"
+    question_description: >
+      Full path of the file to create on the Windows host
+      (for example C:\Temp\example.txt). Leave blank to provide
+      the full file/template lists via extra variables instead.
+    required: false
+    variable: "file_copy_dest"
+    type: "text"
+    default: ""
+
+  - question_name: "File Content"
+    question_description: "Inline text content to write to the destination path"
+    required: false
+    variable: "file_copy_content"
+    type: "textarea"
+    default: ""

--- a/roles/windows_manage_file_copy/README.md
+++ b/roles/windows_manage_file_copy/README.md
@@ -1,0 +1,36 @@
+# windows_manage_file_copy
+
+Copy files and render templates to Windows hosts, optionally setting the path owner.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_file_copy_files` | list(dict) | `[]` | Files/directories to copy (`dest` plus `src` or `content`, optional `force`, `backup`, `remote_src`, `local_follow`, `owner`) |
+| `windows_manage_file_copy_templates` | list(dict) | `[]` | Templates to render (`src`, `dest`, optional Jinja2 delimiter/formatting overrides, `owner`) |
+
+## Example Playbook
+
+```yaml
+- name: Copy files and templates
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_file_copy
+      vars:
+        windows_manage_file_copy_files:
+          - src: files/app.conf
+            dest: C:\Tools\app.conf
+            owner: BUILTIN\Administrators
+        windows_manage_file_copy_templates:
+          - src: settings.conf.j2
+            dest: C:\Tools\settings.conf
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_file_copy/defaults/main.yml
+++ b/roles/windows_manage_file_copy/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# List of files and directories to copy with ansible.windows.win_copy.
+# Owner is set with win_owner when 'owner' is defined on an item.
+windows_manage_file_copy_files: []
+#  - src: /local/src/test.file
+#    dest: C:\Temp\test.file
+#    #owner: BUILTIN\Administrators
+
+# List of templates to render with ansible.windows.win_template.
+# Owner is set with win_owner when 'owner' is defined on an item.
+windows_manage_file_copy_templates: []
+#  - src: settings.conf.j2
+#    dest: C:\Tools\settings.conf
+#    #owner: S-1-5-21-...-1000

--- a/roles/windows_manage_file_copy/meta/argument_specs.yml
+++ b/roles/windows_manage_file_copy/meta/argument_specs.yml
@@ -1,0 +1,28 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Copy files and render templates to Windows hosts.
+    description:
+      - Copy files and directories to Windows hosts with M(ansible.windows.win_copy).
+      - Render Jinja2 templates with M(ansible.windows.win_template).
+      - Optionally set the owner of each destination path with M(ansible.windows.win_owner).
+    options:
+      windows_manage_file_copy_files:
+        type: list
+        elements: dict
+        description:
+          - List of files and directories to copy.
+          - Each item must include C(dest) and either C(src) or C(content).
+          - "Optional keys per item: C(force), C(backup), C(remote_src), C(local_follow), and C(owner)."
+        default: []
+      windows_manage_file_copy_templates:
+        type: list
+        elements: dict
+        description:
+          - List of templates to render to the destination host.
+          - Each item must include C(src) and C(dest).
+          - "Optional keys per item: C(force), C(backup), C(output_encoding), C(newline_sequence),
+            the Jinja2 C(comment_*)/C(variable_*)/C(block_*) delimiter overrides, C(lstrip_blocks),
+            C(trim_blocks), and C(owner)."
+        default: []

--- a/roles/windows_manage_file_copy/meta/main.yml
+++ b/roles/windows_manage_file_copy/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_file_copy
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Copy files and render templates to Windows hosts, optionally setting the path owner.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - files
+    - configuration
+dependencies: []

--- a/roles/windows_manage_file_copy/tasks/main.yml
+++ b/roles/windows_manage_file_copy/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+- name: Copy files
+  ansible.windows.win_copy:
+    src: "{{ item.src | default(omit) }}"
+    content: "{{ item.content | default(omit) }}"
+    dest: "{{ item.dest }}"
+    force: "{{ item.force | default(omit) }}"
+    backup: "{{ item.backup | default(omit) }}"
+    remote_src: "{{ item.remote_src | default(omit) }}"
+    local_follow: "{{ item.local_follow | default(omit) }}"
+  register: windows_manage_file_copy__copy_files
+  loop: "{{ windows_manage_file_copy_files }}"
+  loop_control:
+    label: "{{ item.src | default('(inline content)') + ' -> ' + item.dest }}"
+
+- name: Create files from templates
+  ansible.windows.win_template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    force: "{{ item.force | default(omit) }}"
+    backup: "{{ item.backup | default(omit) }}"
+    output_encoding: "{{ item.output_encoding | default(omit) }}"
+    newline_sequence: "{{ item.newline_sequence | default(omit) }}"
+    comment_start_string: "{{ item.comment_start_string | default(omit) }}"
+    comment_end_string: "{{ item.comment_end_string | default(omit) }}"
+    variable_start_string: "{{ item.variable_start_string | default(omit) }}"
+    variable_end_string: "{{ item.variable_end_string | default(omit) }}"
+    block_start_string: "{{ item.block_start_string | default(omit) }}"
+    block_end_string: "{{ item.block_end_string | default(omit) }}"
+    lstrip_blocks: "{{ item.lstrip_blocks | default(omit) }}"
+    trim_blocks: "{{ item.trim_blocks | default(omit) }}"
+  register: windows_manage_file_copy__copy_templates
+  loop: "{{ windows_manage_file_copy_templates }}"
+  loop_control:
+    label: "{{ item.src + ' -> ' + item.dest }}"
+
+- name: Update path owner
+  ansible.windows.win_owner:
+    path: "{{ item.dest }}"
+    user: "{{ item.owner }}"
+    recurse: false
+  loop: "{{ (windows_manage_file_copy_files + windows_manage_file_copy_templates)
+            | selectattr('owner', 'defined') }}"
+  loop_control:
+    label: "{{ item.dest }}"

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_copy/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_copy/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_copy/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_copy/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Throwaway destination used by the integration test.
+windows_manage_file_copy__test_dest: C:\Windows\Temp\windows_ops_file_copy_test.txt
+windows_manage_file_copy__test_content_a: "infra.windows_ops file_copy state A"
+windows_manage_file_copy__test_content_b: "infra.windows_ops file_copy state B"

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_copy/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_copy/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+- name: Test windows_manage_file_copy
+  block:
+    # -- State A: create the file from inline content --
+    - name: Copy file (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_copy
+      vars:
+        windows_manage_file_copy_files:
+          - dest: "{{ windows_manage_file_copy__test_dest }}"
+            content: "{{ windows_manage_file_copy__test_content_a }}"
+
+    - name: Stat destination after state A
+      ansible.windows.win_stat:
+        path: "{{ windows_manage_file_copy__test_dest }}"
+      register: windows_manage_file_copy__stat_a
+
+    - name: Read destination content after state A
+      ansible.windows.slurp:
+        src: "{{ windows_manage_file_copy__test_dest }}"
+      register: windows_manage_file_copy__slurp_a
+
+    - name: Assert file created with expected content (state A)
+      ansible.builtin.assert:
+        that:
+          - windows_manage_file_copy__stat_a.stat.exists
+          - (windows_manage_file_copy__slurp_a.content | b64decode) == windows_manage_file_copy__test_content_a
+        fail_msg: "File was not created with the expected content in state A"
+
+    # -- Idempotency: re-run state A, expect no change --
+    - name: Copy file again (state A idempotency)
+      ansible.windows.win_copy:
+        dest: "{{ windows_manage_file_copy__test_dest }}"
+        content: "{{ windows_manage_file_copy__test_content_a }}"
+      register: windows_manage_file_copy__idempotent
+
+    - name: Assert re-run reported no change
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_file_copy__idempotent.changed
+        fail_msg: "Copying identical content was not idempotent"
+
+    # -- State B: overwrite with different content --
+    - name: Copy file (state B)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_copy
+      vars:
+        windows_manage_file_copy_files:
+          - dest: "{{ windows_manage_file_copy__test_dest }}"
+            content: "{{ windows_manage_file_copy__test_content_b }}"
+
+    - name: Read destination content after state B
+      ansible.windows.slurp:
+        src: "{{ windows_manage_file_copy__test_dest }}"
+      register: windows_manage_file_copy__slurp_b
+
+    - name: Assert file content updated (state B)
+      ansible.builtin.assert:
+        that:
+          - (windows_manage_file_copy__slurp_b.content | b64decode) == windows_manage_file_copy__test_content_b
+        fail_msg: "File content was not updated in state B"
+
+  always:
+    - name: Remove test file
+      ansible.windows.win_file:
+        path: "{{ windows_manage_file_copy__test_dest }}"
+        state: absent


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_file_copy` role, migrated from the upstream `files_copy` role in myllynen/windows-ansible-roles. Copies files and content to Windows hosts via `ansible.windows.win_copy`.

Part of the ACA-2792 Windows content migration (Batch 5 — Files/Registry). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_file_copy`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_file_copy

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_file_copy_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_file_copy__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. `ansible-lint --profile production` and `yamllint` pass clean.