### PR TITLE
feat(windows_manage_file_create): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-file-create.yml
+++ b/changelogs/fragments/add-windows-manage-file-create.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "windows_manage_file_create - new role for creating directories and files and setting path ownership on Windows hosts
+    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-file-create.yml
+++ b/changelogs/fragments/add-windows-manage-file-create.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - "windows_manage_file_create - new role for creating directories and files and setting path ownership on Windows hosts
-    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+    (https://github.com/redhat-cop/infra.windows_ops/pull/86)."

--- a/extensions/patterns/manage_file_create/exec_env/README.md
+++ b/extensions/patterns/manage_file_create/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_file_create/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_file_create/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_file_create/exec_env/requirements.yml
+++ b/extensions/patterns/manage_file_create/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_file_create/playbooks/run_manage_file_create.yml
+++ b/extensions/patterns/manage_file_create/playbooks/run_manage_file_create.yml
@@ -1,0 +1,14 @@
+---
+- name: Manage Windows File and Directory Creation
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Create files and directories
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_create
+      vars:
+        # A single path can be created via the survey (file_path/file_state).
+        # For multiple items, provide the file_create_items extra variable
+        # (a list of dicts) which overrides the survey values.
+        windows_manage_file_create_items: "{{ file_create_items | default([{'state': file_state | default('directory'), 'path': file_path}]) }}"
+...

--- a/extensions/patterns/manage_file_create/setup.yml
+++ b/extensions/patterns/manage_file_create/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_file_create_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_file_create
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the creation of files and directories.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless creation of directories and files on Windows hosts.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage File Create
+    description: >
+      This job template creates directories and files, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_file_create_pattern
+      - run_manage_file_create
+    playbook: "extensions/patterns/manage_file_create/playbooks/run_manage_file_create.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_file_create.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_file_create/template_surveys/manage_file_create.yml
+++ b/extensions/patterns/manage_file_create/template_surveys/manage_file_create.yml
@@ -1,0 +1,19 @@
+---
+name: "Manage File Create Survey"
+description: "Survey to create a directory or file on Windows hosts"
+spec:
+  - question_name: "Path"
+    question_description: "Full path of the directory or file to create (e.g. C:\\Tools or C:\\Tools\\log.txt)"
+    required: true
+    variable: "file_path"
+    type: "text"
+
+  - question_name: "State"
+    question_description: "Whether the path is a directory or a file"
+    required: true
+    variable: "file_state"
+    type: "multiplechoice"
+    choices:
+      - "directory"
+      - "file"
+    default: "directory"

--- a/roles/windows_manage_file_create/README.md
+++ b/roles/windows_manage_file_create/README.md
@@ -1,0 +1,46 @@
+# windows_manage_file_create
+
+Create directories and files on Windows hosts and optionally set their owner.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_file_create_items` | list(dict) | `[]` | Directories and files to create |
+
+Each item in `windows_manage_file_create_items`:
+
+| Key | Description |
+|---|---|
+| `state` | `directory` or `file` (required) |
+| `path` | Target path (required) |
+| `owner` | Owner to set via `win_owner` (optional) |
+| `recurse` | Recurse when setting owner (optional) |
+| `access_time` / `access_time_format` | File access time (optional, files only) |
+| `modification_time` / `modification_time_format` | File modification time (optional, files only) |
+
+## Example Playbook
+
+```yaml
+- name: Create files and directories
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_file_create
+      vars:
+        windows_manage_file_create_items:
+          - state: directory
+            path: C:\Tools
+            owner: BUILTIN\Administrators
+            recurse: true
+          - state: file
+            path: C:\Tools\log.txt
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_file_create/defaults/main.yml
+++ b/roles/windows_manage_file_create/defaults/main.yml
@@ -1,0 +1,12 @@
+---
+# List of directories and files to create.
+# Directories and files are created with ansible.windows.win_file.
+# The path owner is set with ansible.windows.win_owner when 'owner' is defined.
+windows_manage_file_create_items: []
+#  - state: directory
+#    path: C:\Tools
+#    #owner: BUILTIN\Administrators
+#    #recurse: true
+#  - state: file
+#    path: C:\Tools\log.txt
+#    #owner: S-1-5-21-...-1000

--- a/roles/windows_manage_file_create/meta/argument_specs.yml
+++ b/roles/windows_manage_file_create/meta/argument_specs.yml
@@ -1,0 +1,20 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Create directories and files on Windows.
+    description:
+      - Create directories and files on Windows hosts.
+      - Directories and files are managed with M(ansible.windows.win_file).
+      - The path owner is set with M(ansible.windows.win_owner) when C(owner) is provided.
+    options:
+      windows_manage_file_create_items:
+        type: list
+        elements: dict
+        description:
+          - List of directories and files to create.
+          - Each item must include C(state) (C(directory) or C(file)) and C(path).
+          - "Optional keys per item: C(owner) and C(recurse) (used with M(ansible.windows.win_owner)),
+            and for files C(access_time), C(access_time_format), C(modification_time), and
+            C(modification_time_format)."
+        default: []

--- a/roles/windows_manage_file_create/meta/main.yml
+++ b/roles/windows_manage_file_create/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_file_create
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Create directories and files on Windows hosts and optionally set their owner.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - files
+    - configuration
+dependencies: []

--- a/roles/windows_manage_file_create/tasks/main.yml
+++ b/roles/windows_manage_file_create/tasks/main.yml
@@ -1,0 +1,29 @@
+---
+- name: Create directories
+  ansible.windows.win_file:
+    state: directory
+    path: "{{ item.path }}"
+  loop: "{{ windows_manage_file_create_items | selectattr('state', 'equalto', 'directory') }}"
+  loop_control:
+    label: "{{ item.path }}"
+
+- name: Create files
+  ansible.windows.win_file:
+    state: touch
+    path: "{{ item.path }}"
+    access_time: "{{ item.access_time | default(omit) }}"
+    access_time_format: "{{ item.access_time_format | default(omit) }}"
+    modification_time: "{{ item.modification_time | default(omit) }}"
+    modification_time_format: "{{ item.modification_time_format | default(omit) }}"
+  loop: "{{ windows_manage_file_create_items | selectattr('state', 'equalto', 'file') }}"
+  loop_control:
+    label: "{{ item.path }}"
+
+- name: Update path owner
+  ansible.windows.win_owner:
+    path: "{{ item.path }}"
+    user: "{{ item.owner }}"
+    recurse: "{{ item.recurse | default(omit) }}"
+  loop: "{{ windows_manage_file_create_items | selectattr('owner', 'defined') }}"
+  loop_control:
+    label: "{{ item.path }}"

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_create/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_create/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_create/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_create/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Directory and file created under the Windows temp directory so the test
+# is self-contained and cleaned up in the always block.
+windows_manage_file_create__test_dir: C:\Windows\Temp\windows_ops_test_file_create
+windows_manage_file_create__test_file: C:\Windows\Temp\windows_ops_test_file_create\example.txt

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_create/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_create/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: Test file and directory creation
+  block:
+    # -- State A: create a directory --
+    - name: Create directory (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_create
+      vars:
+        windows_manage_file_create_items:
+          - state: directory
+            path: "{{ windows_manage_file_create__test_dir }}"
+
+    - name: Stat the created directory
+      ansible.windows.win_stat:
+        path: "{{ windows_manage_file_create__test_dir }}"
+      register: windows_manage_file_create__stat_dir
+
+    - name: Assert directory was created
+      ansible.builtin.assert:
+        that:
+          - windows_manage_file_create__stat_dir.stat.exists
+          - windows_manage_file_create__stat_dir.stat.isdir
+        fail_msg: "Directory was not created"
+
+    # -- Idempotency test (directory creation is idempotent) --
+    - name: Create directory again to verify idempotency
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_create
+      vars:
+        windows_manage_file_create_items:
+          - state: directory
+            path: "{{ windows_manage_file_create__test_dir }}"
+      register: windows_manage_file_create__idempotent
+
+    - name: Assert directory creation is idempotent
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_file_create__idempotent.changed
+        fail_msg: "Directory creation is not idempotent - reported changed on re-run"
+
+    # -- State B: create a file inside the directory --
+    - name: Create file (state B)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_create
+      vars:
+        windows_manage_file_create_items:
+          - state: file
+            path: "{{ windows_manage_file_create__test_file }}"
+
+    - name: Stat the created file
+      ansible.windows.win_stat:
+        path: "{{ windows_manage_file_create__test_file }}"
+      register: windows_manage_file_create__stat_file
+
+    - name: Assert file was created
+      ansible.builtin.assert:
+        that:
+          - windows_manage_file_create__stat_file.stat.exists
+          - not windows_manage_file_create__stat_file.stat.isdir
+        fail_msg: "File was not created"
+
+  always:
+    - name: Remove test directory and contents
+      ansible.windows.win_file:
+        path: "{{ windows_manage_file_create__test_dir }}"
+        state: absent


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_file_create` role, migrated from the upstream `files_create` role in myllynen/windows-ansible-roles. Creates files and directories on Windows hosts via `ansible.windows.win_file` and `win_owner`.

Part of the ACA-2792 Windows content migration (Batch 5 — Files/Registry). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_file_create`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_file_create

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_file_create_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_file_create__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. `ansible-lint --profile production` and `yamllint` pass clean.