### PR TITLE
feat(windows_manage_file_fetch): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-file-fetch.yml
+++ b/changelogs/fragments/add-windows-manage-file-fetch.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - windows_manage_file_fetch - new role to fetch files from remote Windows hosts to the Ansible controller (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX).
+  - windows_manage_file_fetch - new role to fetch files from remote Windows hosts to the Ansible controller (https://github.com/redhat-cop/infra.windows_ops/pull/87).

--- a/changelogs/fragments/add-windows-manage-file-fetch.yml
+++ b/changelogs/fragments/add-windows-manage-file-fetch.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - windows_manage_file_fetch - new role to fetch files from remote Windows hosts to the Ansible controller (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX).

--- a/extensions/patterns/manage_file_fetch/exec_env/README.md
+++ b/extensions/patterns/manage_file_fetch/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_file_fetch/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_file_fetch/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_file_fetch/exec_env/requirements.yml
+++ b/extensions/patterns/manage_file_fetch/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_file_fetch/playbooks/run_manage_file_fetch.yml
+++ b/extensions/patterns/manage_file_fetch/playbooks/run_manage_file_fetch.yml
@@ -1,0 +1,13 @@
+---
+- name: Manage file fetch from Windows hosts
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Fetch files from the remote host
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_fetch
+      vars:
+        windows_manage_file_fetch_files:
+          - src: "{{ fetch_src }}"
+            dest: "{{ fetch_dest }}"
+            flat: true

--- a/extensions/patterns/manage_file_fetch/setup.yml
+++ b/extensions/patterns/manage_file_fetch/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_file_fetch_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_file_fetch
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating fetching files from Windows hosts.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless retrieval of files to the controller.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage File Fetch
+    description: >
+      This job template fetches files from Windows hosts to the controller, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_file_fetch_pattern
+      - run_manage_file_fetch
+    playbook: "extensions/patterns/manage_file_fetch/playbooks/run_manage_file_fetch.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_file_fetch.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_file_fetch/template_surveys/manage_file_fetch.yml
+++ b/extensions/patterns/manage_file_fetch/template_surveys/manage_file_fetch.yml
@@ -1,0 +1,16 @@
+---
+name: Manage File Fetch Survey
+description: Survey for fetching a file from a Windows host to the controller.
+spec:
+  - question_name: Source file path
+    question_description: Full path of the file on the remote Windows host to fetch.
+    required: true
+    type: text
+    variable: fetch_src
+    default: ""
+  - question_name: Destination path
+    question_description: Path on the controller where the fetched file is stored.
+    required: true
+    type: text
+    variable: fetch_dest
+    default: ""

--- a/roles/windows_manage_file_fetch/README.md
+++ b/roles/windows_manage_file_fetch/README.md
@@ -1,0 +1,32 @@
+# windows_manage_file_fetch
+
+Fetch files from remote Windows hosts to the Ansible controller.
+
+## Requirements
+
+- Ansible >= 2.18
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_file_fetch_files` | list(dict) | `[]` | Files to fetch (`src`, `dest`, optional `flat`, `fail_on_missing`, `validate_checksum`) |
+
+## Example Playbook
+
+```yaml
+- name: Fetch files from Windows hosts
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_file_fetch
+      vars:
+        windows_manage_file_fetch_files:
+          - src: C:\Temp\log.txt
+            dest: /tmp/log-{{ inventory_hostname }}.txt
+            flat: true
+            validate_checksum: false
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_file_fetch/defaults/main.yml
+++ b/roles/windows_manage_file_fetch/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# List of files to fetch from the remote Windows host to the Ansible controller.
+# Each item: src (remote path) and dest (controller path), plus optional
+# flat, fail_on_missing, and validate_checksum.
+windows_manage_file_fetch_files: []
+#  - src: C:\Temp\log.txt
+#    dest: /tmp/log-{{ inventory_hostname }}.txt
+#    flat: true
+#    validate_checksum: false

--- a/roles/windows_manage_file_fetch/meta/argument_specs.yml
+++ b/roles/windows_manage_file_fetch/meta/argument_specs.yml
@@ -1,0 +1,17 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Fetch files from Windows hosts to the controller.
+    description:
+      - Fetch files from remote Windows hosts to the Ansible controller.
+      - Uses the M(ansible.builtin.fetch) module.
+    options:
+      windows_manage_file_fetch_files:
+        type: list
+        elements: dict
+        description:
+          - List of files to fetch from the remote host.
+          - Each item must include C(src) (remote path) and C(dest) (controller path).
+          - "Optional keys per item: C(flat), C(fail_on_missing), and C(validate_checksum)."
+        default: []

--- a/roles/windows_manage_file_fetch/meta/main.yml
+++ b/roles/windows_manage_file_fetch/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_file_fetch
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Fetch files from remote Windows hosts to the Ansible controller.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - files
+    - configuration
+dependencies: []

--- a/roles/windows_manage_file_fetch/tasks/main.yml
+++ b/roles/windows_manage_file_fetch/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Fetch files from the remote host
+  ansible.builtin.fetch:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    flat: "{{ item.flat | default(omit) }}"
+    fail_on_missing: "{{ item.fail_on_missing | default(omit) }}"
+    validate_checksum: "{{ item.validate_checksum | default(omit) }}"
+  register: windows_manage_file_fetch__result
+  loop: "{{ windows_manage_file_fetch_files }}"
+  loop_control:
+    label: "{{ item.src + ' -> ' + item.dest }}"

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_fetch/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_fetch/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_fetch/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_fetch/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Test verifies fetching a file from a Windows host to the controller.
+windows_ops_test_file_fetch_remote_path: C:\Windows\Temp\windows_manage_file_fetch_test.txt
+windows_ops_test_file_fetch_local_dir: /tmp/windows_manage_file_fetch_test
+windows_ops_test_file_fetch_content: "windows_manage_file_fetch integration test content"

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_fetch/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_fetch/tasks/main.yml
@@ -1,0 +1,63 @@
+---
+- name: Test windows_manage_file_fetch
+  block:
+    - name: Create a throwaway file on the remote host
+      ansible.windows.win_copy:
+        content: "{{ windows_ops_test_file_fetch_content }}"
+        dest: "{{ windows_ops_test_file_fetch_remote_path }}"
+
+    - name: Fetch the file to the controller (first run)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_fetch
+      vars:
+        windows_manage_file_fetch_files:
+          - src: "{{ windows_ops_test_file_fetch_remote_path }}"
+            dest: "{{ windows_ops_test_file_fetch_local_dir }}/fetched.txt"
+            flat: true
+
+    - name: Stat the fetched file on the controller
+      ansible.builtin.stat:
+        path: "{{ windows_ops_test_file_fetch_local_dir }}/fetched.txt"
+      delegate_to: localhost
+      register: windows_ops_test_file_fetch__stat
+
+    - name: Assert the file was fetched with the expected content
+      ansible.builtin.assert:
+        that:
+          - windows_ops_test_file_fetch__stat.stat.exists
+        quiet: true
+        fail_msg: "Fetched file was not found on the controller."
+
+    - name: Read the fetched file content on the controller
+      ansible.builtin.slurp:
+        src: "{{ windows_ops_test_file_fetch_local_dir }}/fetched.txt"
+      delegate_to: localhost
+      register: windows_ops_test_file_fetch__content
+
+    - name: Assert the fetched content matches
+      ansible.builtin.assert:
+        that:
+          - (windows_ops_test_file_fetch__content.content | b64decode) == windows_ops_test_file_fetch_content
+        quiet: true
+        fail_msg: "Fetched file content did not match the source."
+
+    - name: Fetch the file again (idempotency check)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_fetch
+      vars:
+        windows_manage_file_fetch_files:
+          - src: "{{ windows_ops_test_file_fetch_remote_path }}"
+            dest: "{{ windows_ops_test_file_fetch_local_dir }}/fetched.txt"
+            flat: true
+
+  always:
+    - name: Remove the throwaway file from the remote host
+      ansible.windows.win_file:
+        path: "{{ windows_ops_test_file_fetch_remote_path }}"
+        state: absent
+
+    - name: Remove the fetched file directory from the controller
+      ansible.builtin.file:
+        path: "{{ windows_ops_test_file_fetch_local_dir }}"
+        state: absent
+      delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_file_fetch` role, migrated from the upstream `files_fetch` role in myllynen/windows-ansible-roles. Fetches files from Windows hosts back to the controller via `ansible.builtin.fetch`.

Part of the ACA-2792 Windows content migration (Batch 5 — Files/Registry). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_file_fetch`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_file_fetch

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_file_fetch_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_file_fetch__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. `ansible-lint --profile production` and `yamllint` pass clean.