### PR TITLE
feat(windows_manage_file_get): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-file-get.yml
+++ b/changelogs/fragments/add-windows-manage-file-get.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - windows_manage_file_get - new role to download files to Windows hosts over HTTP/HTTPS with optional ownership (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX).

--- a/changelogs/fragments/add-windows-manage-file-get.yml
+++ b/changelogs/fragments/add-windows-manage-file-get.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - windows_manage_file_get - new role to download files to Windows hosts over HTTP/HTTPS with optional ownership (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX).
+  - windows_manage_file_get - new role to download files to Windows hosts over HTTP/HTTPS with optional ownership (https://github.com/redhat-cop/infra.windows_ops/pull/88).

--- a/extensions/patterns/manage_file_get/exec_env/README.md
+++ b/extensions/patterns/manage_file_get/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_file_get/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_file_get/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_file_get/exec_env/requirements.yml
+++ b/extensions/patterns/manage_file_get/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_file_get/playbooks/run_manage_file_get.yml
+++ b/extensions/patterns/manage_file_get/playbooks/run_manage_file_get.yml
@@ -1,0 +1,13 @@
+---
+- name: Download Files to Windows Hosts
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Download files
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_get
+      vars:
+        windows_manage_file_get_files:
+          - url: "{{ file_get_url }}"  # Set by survey
+            dest: "{{ file_get_dest }}"  # Set by survey
+...

--- a/extensions/patterns/manage_file_get/setup.yml
+++ b/extensions/patterns/manage_file_get/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_file_get_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_file_get
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the download of files to Windows hosts.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of file downloads.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage File Get
+    description: >
+      This job template downloads files to Windows hosts, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_file_get_pattern
+      - run_manage_file_get
+    playbook: "extensions/patterns/manage_file_get/playbooks/run_manage_file_get.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_file_get.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_file_get/template_surveys/manage_file_get.yml
+++ b/extensions/patterns/manage_file_get/template_surveys/manage_file_get.yml
@@ -1,0 +1,15 @@
+---
+name: "Manage File Get Survey"
+description: "Survey to download a file to Windows hosts"
+spec:
+  - question_name: "File URL"
+    question_description: "The HTTP or HTTPS URL of the file to download"
+    required: true
+    variable: "file_get_url"
+    type: "text"
+
+  - question_name: "Destination Path"
+    question_description: "The full path on the Windows host to save the file to"
+    required: true
+    variable: "file_get_dest"
+    type: "text"

--- a/roles/windows_manage_file_get/README.md
+++ b/roles/windows_manage_file_get/README.md
@@ -1,0 +1,46 @@
+# windows_manage_file_get
+
+Download files to Windows hosts over HTTP/HTTPS with optional ownership.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_file_get_files` | list(dict) | `[]` | Files to download; each item requires `url` and `dest` |
+| `windows_manage_file_get_no_log` | bool | `true` | Hide task output when an item defines `url_password` |
+
+Each item in `windows_manage_file_get_files` requires `url` and `dest`. Optional
+per-item keys mirror the `ansible.windows.win_get_url` options (for example
+`url_username`, `url_password`, `timeout`, `method`, `validate_certs`,
+`force_basic_auth`, `use_default_credential`, `use_proxy`, `proxy_url`, `headers`,
+`follow_redirects`, `force`, `checksum`, `checksum_algorithm`, `checksum_url`).
+When `owner` is set for an item, the downloaded file's owner is updated with
+`ansible.windows.win_owner`.
+
+## Example Playbook
+
+```yaml
+- name: Download files
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_file_get
+      vars:
+        windows_manage_file_get_files:
+          - url: https://server.example.com/data.zip
+            dest: C:\Temp\data.zip
+            validate_certs: false
+          - url: https://server.example.com/secret.bin
+            url_username: admin
+            url_password: admin123
+            dest: C:\Temp\secret.bin
+            owner: BUILTIN\Administrators
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_file_get/defaults/main.yml
+++ b/roles/windows_manage_file_get/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# List of files to download over the network with ansible.windows.win_get_url.
+# Each item requires url and dest; owner is set with win_owner when defined.
+windows_manage_file_get_files: []
+#  - url: https://server.example.com/data.zip
+#    url_username: admin
+#    url_password: admin123
+#    timeout: 5
+#    validate_certs: false
+#    use_proxy: false
+#    dest: C:\Temp\data.zip
+#    #owner: S-1-5-21-...-1000
+
+# Value for the no_log parameter when downloading files with passwords.
+# Has no effect when no item defines url_password.
+windows_manage_file_get_no_log: true

--- a/roles/windows_manage_file_get/meta/argument_specs.yml
+++ b/roles/windows_manage_file_get/meta/argument_specs.yml
@@ -1,0 +1,35 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Download files to Windows hosts.
+    description:
+      - Download one or more files to Windows hosts over HTTP or HTTPS with
+        C(ansible.windows.win_get_url).
+      - Optionally set the owner of each downloaded file with
+        C(ansible.windows.win_owner).
+    options:
+      windows_manage_file_get_files:
+        type: list
+        elements: dict
+        description:
+          - List of files to download.
+          - Each item must include C(url) and C(dest).
+          - Optional per-item keys mirror the C(ansible.windows.win_get_url)
+            options, for example C(url_username), C(url_password), C(timeout),
+            C(method), C(validate_certs), C(force_basic_auth),
+            C(use_default_credential), C(http_agent), C(use_proxy), C(proxy_url),
+            C(proxy_username), C(proxy_password), C(proxy_use_default_credential),
+            C(headers), C(follow_redirects), C(maximum_redirection),
+            C(client_cert), C(client_cert_password), C(force), C(checksum),
+            C(checksum_algorithm), and C(checksum_url).
+          - When C(owner) is set for an item, the downloaded file's owner is
+            updated with C(ansible.windows.win_owner).
+        default: []
+      windows_manage_file_get_no_log:
+        type: bool
+        description:
+          - Whether to hide task output when any downloaded item defines
+            C(url_password).
+          - Has no effect when no item defines C(url_password).
+        default: true

--- a/roles/windows_manage_file_get/meta/main.yml
+++ b/roles/windows_manage_file_get/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_file_get
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Download files to Windows hosts over HTTP/HTTPS with optional ownership.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - files
+    - download
+dependencies: []

--- a/roles/windows_manage_file_get/tasks/main.yml
+++ b/roles/windows_manage_file_get/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+- name: Download files
+  vars:
+    windows_manage_file_get__passwords_used: "{{ windows_manage_file_get_files | selectattr('url_password', 'defined') | length > 0 }}"
+  no_log: "{{ windows_manage_file_get__passwords_used and windows_manage_file_get_no_log }}"
+  ansible.windows.win_get_url:
+    url: "{{ item.url }}"
+    url_username: "{{ item.url_username | default(omit) }}"
+    url_password: "{{ item.url_password | default(omit) }}"
+    url_timeout: "{{ item.timeout | default(omit) }}"
+    url_method: "{{ item.method | default(omit) }}"
+    validate_certs: "{{ item.validate_certs | default(omit) }}"
+    force_basic_auth: "{{ item.force_basic_auth | default(omit) }}"
+    use_default_credential: "{{ item.use_default_credential | default(omit) }}"
+    http_agent: "{{ item.http_agent | default(omit) }}"
+    use_proxy: "{{ item.use_proxy | default(omit) }}"
+    proxy_url: "{{ item.proxy_url | default(omit) }}"
+    proxy_username: "{{ item.proxy_username | default(omit) }}"
+    proxy_password: "{{ item.proxy_password | default(omit) }}"
+    proxy_use_default_credential: "{{ item.proxy_use_default_credential | default(omit) }}"
+    headers: "{{ item.headers | default(omit) }}"
+    follow_redirects: "{{ item.follow_redirects | default(omit) }}"
+    maximum_redirection: "{{ item.maximum_redirection | default(omit) }}"
+    client_cert: "{{ item.client_cert | default(omit) }}"
+    client_cert_password: "{{ item.client_cert_password | default(omit) }}"
+    dest: "{{ item.dest }}"
+    force: "{{ item.force | default(omit) }}"
+    checksum: "{{ item.checksum | default(omit) }}"
+    checksum_algorithm: "{{ item.checksum_algorithm | default(omit) }}"
+    checksum_url: "{{ item.checksum_url | default(omit) }}"
+  register: windows_manage_file_get__results
+  loop: "{{ windows_manage_file_get_files }}"
+  loop_control:
+    label: "{{ item.dest }}"
+
+- name: Update path owner
+  ansible.windows.win_owner:
+    path: "{{ item.dest }}"
+    user: "{{ item.owner }}"
+    recurse: false
+  loop: "{{ windows_manage_file_get_files | selectattr('owner', 'defined') }}"
+  loop_control:
+    label: "{{ item.dest }}"

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_get/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_get/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_get/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_get/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Test downloads a small, stable file over HTTPS and verifies idempotency.
+# NOTE: this target requires outbound HTTPS access from the Windows host.
+windows_manage_file_get__test_url: https://www.example.com/
+windows_manage_file_get__test_dest: C:\Windows\Temp\windows_manage_file_get_test.html

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_get/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_get/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+- name: Test file download
+  block:
+    - name: Ensure test file is absent before starting
+      ansible.windows.win_file:
+        path: "{{ windows_manage_file_get__test_dest }}"
+        state: absent
+
+    # -- State A: initial download --
+    - name: Download file (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_get
+      vars:
+        windows_manage_file_get_files:
+          - url: "{{ windows_manage_file_get__test_url }}"
+            dest: "{{ windows_manage_file_get__test_dest }}"
+
+    - name: Stat downloaded file after state A
+      ansible.windows.win_stat:
+        path: "{{ windows_manage_file_get__test_dest }}"
+      register: windows_manage_file_get__stat_a
+
+    - name: Assert file was downloaded
+      ansible.builtin.assert:
+        that:
+          - windows_manage_file_get__stat_a.stat.exists
+          - windows_manage_file_get__stat_a.stat.size > 0
+        fail_msg: "File was not downloaded"
+
+    # -- Idempotency test: re-run must not modify the existing file --
+    - name: Download file again to verify idempotency
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_get
+      vars:
+        windows_manage_file_get_files:
+          - url: "{{ windows_manage_file_get__test_url }}"
+            dest: "{{ windows_manage_file_get__test_dest }}"
+
+    - name: Stat downloaded file after idempotent re-run
+      ansible.windows.win_stat:
+        path: "{{ windows_manage_file_get__test_dest }}"
+      register: windows_manage_file_get__stat_idempotent
+
+    - name: Assert file was not modified on re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_file_get__stat_idempotent.stat.lastwritetime == windows_manage_file_get__stat_a.stat.lastwritetime
+        fail_msg: "Role is not idempotent - file was re-downloaded on re-run"
+
+  always:
+    - name: Remove downloaded test file
+      ansible.windows.win_file:
+        path: "{{ windows_manage_file_get__test_dest }}"
+        state: absent


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_file_get` role, migrated from the upstream `files_get` role in myllynen/windows-ansible-roles. Downloads files to Windows hosts via `ansible.windows.win_get_url` (with optional ownership via `win_owner`).

Part of the ACA-2792 Windows content migration (Batch 5 — Files/Registry). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_file_get`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_file_get

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_file_get_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_file_get__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. `ansible-lint --profile production` and `yamllint` pass clean.