### PR TITLE
feat(windows_manage_file_remove): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-file-remove.yml
+++ b/changelogs/fragments/add-windows-manage-file-remove.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - "windows_manage_file_remove - new role for removing files and directories on Windows with wildcard and exclusion support
+    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-file-remove.yml
+++ b/changelogs/fragments/add-windows-manage-file-remove.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
   - "windows_manage_file_remove - new role for removing files and directories on Windows with wildcard and exclusion support
-    (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+    (https://github.com/redhat-cop/infra.windows_ops/pull/89)."

--- a/extensions/patterns/manage_file_remove/exec_env/README.md
+++ b/extensions/patterns/manage_file_remove/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_file_remove/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_file_remove/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_file_remove/exec_env/requirements.yml
+++ b/extensions/patterns/manage_file_remove/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_file_remove/playbooks/run_manage_file_remove.yml
+++ b/extensions/patterns/manage_file_remove/playbooks/run_manage_file_remove.yml
@@ -1,0 +1,14 @@
+---
+- name: Manage Windows File Removal
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Remove files and directories
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_remove
+      vars:
+        # The list of paths to remove is provided via extra_vars as
+        # windows_manage_file_remove_paths (a survey cannot collect a list).
+        windows_manage_file_remove_recursive: "{{ file_remove_recursive | default(false) | bool }}"  # Set by survey
+        windows_manage_file_remove_case_sensitive: "{{ file_remove_case_sensitive | default(false) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_file_remove/setup.yml
+++ b/extensions/patterns/manage_file_remove/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_file_remove_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_file_remove
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the removal of files and directories.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of file cleanup.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage File Remove
+    description: >
+      This job template removes files and directories, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_file_remove_pattern
+      - run_manage_file_remove
+    playbook: "extensions/patterns/manage_file_remove/playbooks/run_manage_file_remove.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_file_remove.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_file_remove/template_surveys/manage_file_remove.yml
+++ b/extensions/patterns/manage_file_remove/template_surveys/manage_file_remove.yml
@@ -1,0 +1,23 @@
+---
+name: "Manage File Removal Survey"
+description: "Survey to configure file and directory removal options"
+spec:
+  - question_name: "Recursive Wildcard Search"
+    question_description: "Use a recursive find when expanding wildcard patterns"
+    required: true
+    variable: "file_remove_recursive"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Case-Sensitive Matching"
+    question_description: "Enable case-sensitive matching when expanding wildcard patterns"
+    required: true
+    variable: "file_remove_case_sensitive"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"

--- a/roles/windows_manage_file_remove/README.md
+++ b/roles/windows_manage_file_remove/README.md
@@ -1,0 +1,40 @@
+# windows_manage_file_remove
+
+Remove files and directories on Windows, with wildcard and exclusion support.
+
+> **Warning:** Be very careful with this role. Typos or unexpected wildcard expansion can remove
+> unintended files and directories across all managed systems with no confirmation.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_file_remove_paths` | list(str) | `[]` | Files and directories to remove (wildcards allowed in the last element only) |
+| `windows_manage_file_remove_recursive` | bool | `false` | Use recursive find for wildcard patterns |
+| `windows_manage_file_remove_exclude` | list(str) | `[]` | Full paths to exclude from removal (no wildcards) |
+| `windows_manage_file_remove_case_sensitive` | bool | `false` | Case-sensitive wildcard matching |
+
+## Example Playbook
+
+```yaml
+- name: Remove temporary files
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_file_remove
+      vars:
+        windows_manage_file_remove_paths:
+          - C:\Temp\log.txt
+          - C:\Temp\*.old
+        windows_manage_file_remove_exclude:
+          - C:\Temp\keep.old
+        windows_manage_file_remove_recursive: false
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_file_remove/defaults/main.yml
+++ b/roles/windows_manage_file_remove/defaults/main.yml
@@ -1,0 +1,24 @@
+---
+# NB. Be *very* careful with this role as any typos or unexpected wildcard
+# expansion might cause unintended files and directories to be removed across
+# all the managed systems with no questions asked! You have been warned.
+
+# List of files and directories to remove.
+# Wildcards are supported for the last path element only; directories are
+# removed recursively.
+windows_manage_file_remove_paths: []
+#  - C:\Tools\conf\*.conf
+#  - C:\Temp\log.txt
+#  - C:\Temp\testdir
+#  - C:\Temp\*.old
+
+# Use recursive find for the wildcard patterns above. Be extremely careful:
+# C:\Temp\*.old will also remove C:\Temp\save\y.old!
+windows_manage_file_remove_recursive: false
+
+# List of items to exclude from removal. Useful with wildcards, optional.
+windows_manage_file_remove_exclude: []
+#  - C:\Tools\conf\base.conf
+
+# Enable or disable case-sensitive find
+windows_manage_file_remove_case_sensitive: false

--- a/roles/windows_manage_file_remove/meta/argument_specs.yml
+++ b/roles/windows_manage_file_remove/meta/argument_specs.yml
@@ -1,0 +1,34 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Remove Windows files and directories.
+    description:
+      - Remove files and directories from Windows hosts.
+      - Wildcards are supported for the last path element only; directories are removed recursively.
+      - "B(WARNING): Unexpected wildcard expansion can remove unintended files. Use with care."
+    options:
+      windows_manage_file_remove_paths:
+        type: list
+        elements: str
+        description:
+          - List of files and directories to remove.
+          - Wildcards (C(*), C(?), C([)) are supported for the last path element only.
+        default: []
+      windows_manage_file_remove_recursive:
+        type: bool
+        description:
+          - Use a recursive find when expanding wildcard patterns.
+        default: false
+      windows_manage_file_remove_exclude:
+        type: list
+        elements: str
+        description:
+          - List of full paths to exclude from removal.
+          - Wildcards are not supported for exclusion entries.
+        default: []
+      windows_manage_file_remove_case_sensitive:
+        type: bool
+        description:
+          - Enable case-sensitive matching when expanding wildcard patterns.
+        default: false

--- a/roles/windows_manage_file_remove/meta/main.yml
+++ b/roles/windows_manage_file_remove/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_file_remove
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Remove files and directories on Windows, with wildcard and exclusion support.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - files
+    - configuration
+dependencies: []

--- a/roles/windows_manage_file_remove/tasks/main.yml
+++ b/roles/windows_manage_file_remove/tasks/main.yml
@@ -1,0 +1,67 @@
+---
+- name: Ensure no unsafe wildcard is used
+  ansible.builtin.assert:
+    that:
+      - "'*' not in windows_manage_file_remove_paths"
+      - "'C:\\*' not in windows_manage_file_remove_paths"
+    fail_msg: "Refusing to expand unsafe wildcard '*'."
+    quiet: true
+
+- name: Ensure removal and exclude paths use backslash separators
+  ansible.builtin.assert:
+    that:
+      - "'\\\\' in item"
+    fail_msg: "Path '{{ item }}' must contain '\\'."
+    quiet: true
+  loop: "{{ windows_manage_file_remove_paths + windows_manage_file_remove_exclude }}"
+
+- name: Ensure exclude entries contain no wildcards
+  ansible.builtin.assert:
+    that:
+      - "'*' not in item"
+      - "'?' not in item"
+      - "'[' not in item"
+    fail_msg: "Wildcards not supported for exclusion."
+    quiet: true
+  loop: "{{ windows_manage_file_remove_exclude }}"
+
+- name: Ensure wildcards only appear in the last path element
+  ansible.builtin.assert:
+    that:
+      - windows_manage_file_remove_paths | map('win_dirname') | select('search', '\\?|\\*|\\[') | length == 0
+    fail_msg: "Wildcards only supported for the last element."
+    quiet: true
+
+- name: Locate wildcard files and directories to be removed
+  ansible.windows.win_find:
+    paths: "{{ item | win_dirname }}"
+    patterns: "{{ item | win_basename }}"
+    file_type: any
+    hidden: true
+    recurse: "{{ windows_manage_file_remove_recursive | bool }}"
+    case_sensitive: "{{ windows_manage_file_remove_case_sensitive | bool }}"
+  register: windows_manage_file_remove__found
+  loop: "{{ windows_manage_file_remove_paths | select('search', '\\?|\\*|\\[') }}"
+
+# Reset the list on each execution in case the role runs more than once per play.
+- name: Initialize list of wildcard files and directories
+  ansible.builtin.set_fact:
+    windows_manage_file_remove__wildcard_paths: []
+
+- name: Set wildcard files and directories to remove
+  ansible.builtin.set_fact:
+    windows_manage_file_remove__wildcard_paths: "{{ windows_manage_file_remove__wildcard_paths + item.files | map(attribute='path') }}"
+  loop: "{{ windows_manage_file_remove__found.results }}"
+  loop_control:
+    label: "{{ item.files | map(attribute='path') }}"
+  when: item.files | length > 0
+
+- name: Remove files and directories
+  vars:
+    windows_manage_file_remove__plain_paths: "{{ windows_manage_file_remove_paths | reject('search', '\\?|\\*|\\[') }}"
+  ansible.windows.win_file:
+    path: "{{ item }}"
+    state: absent
+  register: windows_manage_file_remove__removed
+  loop: "{{ windows_manage_file_remove__plain_paths + windows_manage_file_remove__wildcard_paths }}"
+  when: item not in windows_manage_file_remove_exclude

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_remove/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_remove/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_remove/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_remove/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Throwaway workspace created and destroyed by the test.
+windows_manage_file_remove__test_dir: C:\Windows\Temp\windows_ops_test_file_remove

--- a/tests/integration/targets/windows_ops_test_windows_manage_file_remove/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_file_remove/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+- name: Test file and directory removal
+  block:
+    # -- Setup: create a throwaway workspace with plain and wildcard targets --
+    - name: Create test workspace and subdirectory
+      ansible.windows.win_file:
+        path: "{{ windows_manage_file_remove__test_dir }}\\keep\\nested"
+        state: directory
+
+    - name: Create test files
+      ansible.windows.win_copy:
+        content: "test"
+        dest: "{{ windows_manage_file_remove__test_dir }}\\{{ item }}"
+      loop:
+        - plain.txt
+        - first.log
+        - second.log
+        - keep.log
+
+    # -- Remove: one plain file and a wildcard pattern, excluding keep.log --
+    - name: Remove files and directories
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_remove
+      vars:
+        windows_manage_file_remove_paths:
+          - "{{ windows_manage_file_remove__test_dir }}\\plain.txt"
+          - "{{ windows_manage_file_remove__test_dir }}\\*.log"
+        windows_manage_file_remove_exclude:
+          - "{{ windows_manage_file_remove__test_dir }}\\keep.log"
+
+    - name: Stat targets after removal
+      ansible.windows.win_stat:
+        path: "{{ windows_manage_file_remove__test_dir }}\\{{ item }}"
+      register: windows_manage_file_remove__after
+      loop:
+        - plain.txt
+        - first.log
+        - second.log
+        - keep.log
+
+    - name: Assert removed and excluded targets are in the expected state
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_file_remove__after.results[0].stat.exists
+          - not windows_manage_file_remove__after.results[1].stat.exists
+          - not windows_manage_file_remove__after.results[2].stat.exists
+          - windows_manage_file_remove__after.results[3].stat.exists
+        fail_msg: "Removal did not match expectations (excluded keep.log must survive)."
+
+    # -- Idempotency: re-run must report no change --
+    - name: Remove files and directories again (idempotency check)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_file_remove
+      vars:
+        windows_manage_file_remove_paths:
+          - "{{ windows_manage_file_remove__test_dir }}\\plain.txt"
+          - "{{ windows_manage_file_remove__test_dir }}\\*.log"
+        windows_manage_file_remove_exclude:
+          - "{{ windows_manage_file_remove__test_dir }}\\keep.log"
+
+    - name: Assert re-run made no changes
+      ansible.builtin.assert:
+        that:
+          - windows_manage_file_remove__removed is not changed
+        fail_msg: "Role is not idempotent - re-run reported changes."
+
+  always:
+    - name: Clean up test workspace
+      ansible.windows.win_file:
+        path: "{{ windows_manage_file_remove__test_dir }}"
+        state: absent


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_file_remove` role, migrated from the upstream `files_remove` role in myllynen/windows-ansible-roles. Removes files and directories (including wildcard matches with excludes) on Windows hosts via `ansible.windows.win_find` and `win_file`.

Part of the ACA-2792 Windows content migration (Batch 5 — Files/Registry). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_file_remove`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_file_remove

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_file_remove_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_file_remove__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. `ansible-lint --profile production` and `yamllint` pass clean.