### PR TITLE
feat(windows_manage_registry): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-registry.yml
+++ b/changelogs/fragments/add-windows-manage-registry.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - windows_manage_registry - new role to apply system-wide Windows registry settings with ``ansible.windows.win_regedit``, including optional per-setting reboot handling (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX).

--- a/changelogs/fragments/add-windows-manage-registry.yml
+++ b/changelogs/fragments/add-windows-manage-registry.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - windows_manage_registry - new role to apply system-wide Windows registry settings with ``ansible.windows.win_regedit``, including optional per-setting reboot handling (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX).
+  - windows_manage_registry - new role to apply system-wide Windows registry settings with ``ansible.windows.win_regedit``, including optional per-setting reboot handling (https://github.com/redhat-cop/infra.windows_ops/pull/90).

--- a/extensions/patterns/manage_registry/exec_env/README.md
+++ b/extensions/patterns/manage_registry/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_registry/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_registry/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_registry/exec_env/requirements.yml
+++ b/extensions/patterns/manage_registry/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_registry/playbooks/run_manage_registry.yml
+++ b/extensions/patterns/manage_registry/playbooks/run_manage_registry.yml
@@ -1,0 +1,14 @@
+---
+- name: Manage Windows Registry Settings
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Apply registry settings
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_registry
+      vars:
+        # The registry settings list is not survey-friendly; provide it as
+        # extra variables (for example via a job template extra_vars or a
+        # variable set) using the windows_manage_registry_settings structure.
+        windows_manage_registry_reboot: "{{ registry_reboot | default(true) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_registry/setup.yml
+++ b/extensions/patterns/manage_registry/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_registry_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_registry
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of registry settings.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of Windows registry configurations.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Registry
+    description: >
+      This job template manages Windows registry settings, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_registry_pattern
+      - run_manage_registry
+    playbook: "extensions/patterns/manage_registry/playbooks/run_manage_registry.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_registry.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_registry/template_surveys/manage_registry.yml
+++ b/extensions/patterns/manage_registry/template_surveys/manage_registry.yml
@@ -1,0 +1,15 @@
+---
+name: "Manage Registry Settings Survey"
+description: "Survey to configure registry management options"
+spec:
+  - question_name: "Reboot After Changes"
+    question_description: >
+      Allow a reboot after registry changes. A reboot only occurs when a
+      changed setting is marked with 'reboot: true'.
+    required: true
+    variable: "registry_reboot"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"

--- a/roles/windows_manage_registry/README.md
+++ b/roles/windows_manage_registry/README.md
@@ -1,0 +1,59 @@
+# windows_manage_registry
+
+Apply system-wide Windows registry settings with `ansible.windows.win_regedit`, with optional per-setting reboot handling.
+
+For user-specific registry settings, see the `windows_manage_user_settings` role.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_registry_settings` | list(dict) | `[]` | List of registry settings to apply (see item keys below) |
+| `windows_manage_registry_reboot` | bool | `true` | Allow reboot after changes; only reboots when a changed item has `reboot: true` |
+
+Each item in `windows_manage_registry_settings` supports:
+
+| Key | Required | Description |
+|---|---|---|
+| `setting` | yes | Human-readable label for the setting |
+| `path` | yes | Full registry path, e.g. `HKLM:\SOFTWARE\...` |
+| `name` | no | Value name (omit to act on the key itself) |
+| `type` | no | `none`, `binary`, `dword`, `expandstring`, `multistring`, `string`, `qword` |
+| `data` | no | Value data |
+| `state` | no | `present` (default) or `absent` |
+| `reboot` | no | Whether this setting requires a reboot (default `false`) |
+
+## Example Playbook
+
+```yaml
+- name: Apply registry settings
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_registry
+      vars:
+        windows_manage_registry_reboot: true
+        windows_manage_registry_settings:
+          - setting: Allow full admin privileges for local admins over WinRM
+            path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+            name: LocalAccountTokenFilterPolicy
+            type: DWord
+            data: 1
+          - setting: Enable User Account Control (UAC)
+            path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+            name: EnableLUA
+            type: DWord
+            data: 1
+            reboot: true
+          - setting: Enable new network location wizard
+            path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+            state: absent
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_registry/defaults/main.yml
+++ b/roles/windows_manage_registry/defaults/main.yml
@@ -1,0 +1,35 @@
+---
+# Registry settings to apply with ansible.windows.win_regedit.
+# For user-specific settings see windows_manage_user_settings.
+#
+# Each item is a dictionary describing one registry value or key:
+#   setting: Human-readable label for the setting (required)
+#   path:    Full registry path, e.g. HKLM:\SOFTWARE\... (required)
+#   name:    Value name (omit to act on the key itself)
+#   type:    none, binary, dword, expandstring, multistring, string, qword
+#   data:    Value data
+#   state:   present (default) or absent
+#   reboot:  Whether this setting requires a reboot (default false)
+#
+# Example:
+#  - setting: Allow full admin privileges for local admins over WinRM
+#    path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+#    name: LocalAccountTokenFilterPolicy
+#    type: DWord
+#    data: 1
+#
+#  - setting: Enable User Account Control (UAC)
+#    path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+#    name: EnableLUA
+#    type: DWord
+#    data: 1
+#    reboot: true
+#
+#  - setting: Enable new network location wizard
+#    path: HKLM:\SYSTEM\CurrentControlSet\Control\Network\NewNetworkWindowOff
+#    state: absent
+windows_manage_registry_settings: []
+
+# Reboot after registry changes.
+# A reboot only occurs when a changed setting has "reboot: true".
+windows_manage_registry_reboot: true

--- a/roles/windows_manage_registry/meta/argument_specs.yml
+++ b/roles/windows_manage_registry/meta/argument_specs.yml
@@ -1,0 +1,31 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Apply system-wide Windows registry settings.
+    description:
+      - Create, update, and remove Windows registry keys and values with
+        M(ansible.windows.win_regedit).
+      - Optionally reboots the host when a changed setting requires it.
+      - For user-specific settings see the C(windows_manage_user_settings) role.
+    options:
+      windows_manage_registry_settings:
+        type: list
+        elements: dict
+        description:
+          - List of registry settings to apply.
+          - Each item must include C(setting) (a human-readable label) and C(path)
+            (the full registry path, for example C(HKLM:\SOFTWARE\...)).
+          - Include C(name), C(type), and C(data) to manage a value; omit them
+            (with C(state=absent)) to act on the key itself.
+          - "C(type) accepts one of: C(none), C(binary), C(dword), C(expandstring),
+            C(multistring), C(string), C(qword)."
+          - C(state) is C(present) (default) or C(absent).
+          - Set C(reboot) to C(true) on an item to trigger a reboot when that item changes.
+        default: []
+      windows_manage_registry_reboot:
+        type: bool
+        description:
+          - Allow the role to reboot the host after registry changes.
+          - "A reboot only occurs when a changed setting is marked with C(reboot: true)."
+        default: true

--- a/roles/windows_manage_registry/meta/main.yml
+++ b/roles/windows_manage_registry/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_registry
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Apply system-wide Windows registry settings with ansible.windows.win_regedit.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - registry
+    - configuration
+dependencies: []

--- a/roles/windows_manage_registry/tasks/main.yml
+++ b/roles/windows_manage_registry/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Verify registry settings format
+  ansible.builtin.assert:
+    that:
+      - item.keys() | difference(['setting', 'path', 'name', 'type', 'data', 'state', 'reboot']) | length == 0
+      - item.setting is defined and item.setting is string
+      - item.path is defined and item.path is string
+      - "':' in item.path"
+      - item.state | default('present') in ['absent', 'present']
+      - (item.state | default('present') == 'absent' if item.name is not defined or
+                                                        item.type is not defined or
+                                                        item.data is not defined else true)
+      - (item.type | default('string') | lower in ['none', 'binary', 'dword',
+                                                   'expandstring', 'multistring',
+                                                   'string', 'qword'] if item.type is defined else true)
+    fail_msg: |
+      Invalid or incomplete registry setting:
+
+      {{ item | to_nice_yaml }}
+    quiet: true
+  loop: "{{ windows_manage_registry_settings }}"
+  loop_control:
+    label: "{{ item.setting | default('') }}"
+
+- name: Apply registry settings
+  ansible.windows.win_regedit:
+    hive: "{{ item.hive | default(omit) }}"
+    path: "{{ item.path }}"
+    state: "{{ item.state | default('present') }}"
+    name: "{{ item.name | default(omit) }}"
+    type: "{{ item.type | default(omit) }}"
+    data: "{{ item.data | default(omit) }}"
+    delete_key: "{{ item.delete_key | default(true) }}"
+  register: windows_manage_registry__config
+  loop: "{{ windows_manage_registry_settings }}"
+  loop_control:
+    label: "{{ item.setting }}"
+
+- name: Reboot system
+  vars:
+    windows_manage_registry__reboot_needed: "{{ windows_manage_registry__config.results
+                                                 | selectattr('item.reboot', 'defined')
+                                                 | selectattr('item.reboot', 'equalto', true)
+                                                 | selectattr('changed', 'equalto', true) | length > 0 }}"
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: "Ansible reboot after registry changes"
+  when:
+    - windows_manage_registry_reboot | bool
+    - windows_manage_registry__config is changed
+    - windows_manage_registry__reboot_needed

--- a/tests/integration/targets/windows_ops_test_windows_manage_registry/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_registry/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_registry/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_registry/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Test applies throwaway registry values under a dedicated test key so the
+# host's real configuration is never touched. The key is removed in "always".
+windows_manage_registry_test_path: HKLM:\SOFTWARE\_ansible_windows_ops_test
+windows_manage_registry_test_name: TestValue

--- a/tests/integration/targets/windows_ops_test_windows_manage_registry/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_registry/tasks/main.yml
@@ -1,0 +1,117 @@
+---
+- name: Test registry settings management
+  block:
+    - name: Ensure test key is absent before starting
+      ansible.windows.win_regedit:
+        path: "{{ windows_manage_registry_test_path }}"
+        state: absent
+        delete_key: true
+
+    # -- State A: create a DWord value --
+    - name: Apply registry settings (state A - DWord data 1)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_registry
+      vars:
+        windows_manage_registry_reboot: false
+        windows_manage_registry_settings:
+          - setting: Test value A
+            path: "{{ windows_manage_registry_test_path }}"
+            name: "{{ windows_manage_registry_test_name }}"
+            type: dword
+            data: 1
+
+    - name: Verify value after state A
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_registry_test_path }}"
+        name: "{{ windows_manage_registry_test_name }}"
+      register: windows_manage_registry_verify_a
+
+    - name: Assert value is set to 1
+      ansible.builtin.assert:
+        that:
+          - windows_manage_registry_verify_a.exists
+          - windows_manage_registry_verify_a.value == 1
+        fail_msg: "Registry value was not set to 1 after state A"
+
+    # -- Idempotency test --
+    - name: Apply registry settings again (idempotency)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_registry
+      vars:
+        windows_manage_registry_reboot: false
+        windows_manage_registry_settings:
+          - setting: Test value A
+            path: "{{ windows_manage_registry_test_path }}"
+            name: "{{ windows_manage_registry_test_name }}"
+            type: dword
+            data: 1
+      register: windows_manage_registry_idempotent
+
+    - name: Verify value unchanged after idempotent re-run
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_registry_test_path }}"
+        name: "{{ windows_manage_registry_test_name }}"
+      register: windows_manage_registry_verify_idempotent
+
+    - name: Assert role is idempotent
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_registry_idempotent.changed
+          - windows_manage_registry_verify_idempotent.value == 1
+        fail_msg: "Role is not idempotent - registry changed on re-run"
+
+    # -- State B: update the value --
+    - name: Apply registry settings (state B - DWord data 2)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_registry
+      vars:
+        windows_manage_registry_reboot: false
+        windows_manage_registry_settings:
+          - setting: Test value B
+            path: "{{ windows_manage_registry_test_path }}"
+            name: "{{ windows_manage_registry_test_name }}"
+            type: dword
+            data: 2
+
+    - name: Verify value after state B
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_registry_test_path }}"
+        name: "{{ windows_manage_registry_test_name }}"
+      register: windows_manage_registry_verify_b
+
+    - name: Assert value is updated to 2
+      ansible.builtin.assert:
+        that:
+          - windows_manage_registry_verify_b.value == 2
+        fail_msg: "Registry value was not updated to 2 after state B"
+
+    # -- State C: remove the value --
+    - name: Remove registry value (state C - absent)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_registry
+      vars:
+        windows_manage_registry_reboot: false
+        windows_manage_registry_settings:
+          - setting: Remove test value
+            path: "{{ windows_manage_registry_test_path }}"
+            name: "{{ windows_manage_registry_test_name }}"
+            state: absent
+
+    - name: Verify value removed after state C
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_registry_test_path }}"
+        name: "{{ windows_manage_registry_test_name }}"
+      register: windows_manage_registry_verify_c
+
+    - name: Assert value is removed
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_registry_verify_c.exists
+        fail_msg: "Registry value was not removed after state C"
+
+  always:
+    - name: Remove test key
+      ansible.windows.win_regedit:
+        path: "{{ windows_manage_registry_test_path }}"
+        state: absent
+        delete_key: true


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_registry` role, migrated from the upstream `registry_settings` role in myllynen/windows-ansible-roles. Manages Windows registry values via `ansible.windows.win_regedit`, with optional reboot handling.

Part of the ACA-2792 Windows content migration (Batch 5 — Files/Registry). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_registry`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_registry

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_registry_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_registry__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. `ansible-lint --profile production` and `yamllint` pass clean.