### PR TITLE
feat(windows_manage_features): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-features.yml
+++ b/changelogs/fragments/add-windows-manage-features.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "windows_manage_features - new role for installing and removing Windows Server roles and features (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+  - "windows_manage_features - new role for installing and removing Windows Server roles and features (https://github.com/redhat-cop/infra.windows_ops/pull/91)."

--- a/changelogs/fragments/add-windows-manage-features.yml
+++ b/changelogs/fragments/add-windows-manage-features.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_features - new role for installing and removing Windows Server roles and features (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/extensions/patterns/manage_features/exec_env/README.md
+++ b/extensions/patterns/manage_features/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_features/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_features/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_features/exec_env/requirements.yml
+++ b/extensions/patterns/manage_features/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_features/playbooks/run_manage_features.yml
+++ b/extensions/patterns/manage_features/playbooks/run_manage_features.yml
@@ -1,0 +1,14 @@
+---
+- name: Manage Windows Features
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Manage features
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_features
+      vars:
+        windows_manage_features_reboot: "{{ features_reboot | default(true) | bool }}"  # Set by survey
+        windows_manage_features_remove_ignore_unknown: "{{ features_ignore_unknown | default(true) | bool }}"  # Set by survey
+        # The feature lists are not survey-friendly; supply them as job template
+        # extra_vars: windows_manage_features_install and windows_manage_features_remove.
+...

--- a/extensions/patterns/manage_features/setup.yml
+++ b/extensions/patterns/manage_features/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_features_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_features
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of Windows features.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of Windows roles and features.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Features
+    description: >
+      This job template installs and removes Windows roles and features, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_features_pattern
+      - run_manage_features
+    playbook: "extensions/patterns/manage_features/playbooks/run_manage_features.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_features.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_features/template_surveys/manage_features.yml
+++ b/extensions/patterns/manage_features/template_surveys/manage_features.yml
@@ -1,0 +1,23 @@
+---
+name: "Manage Features Survey"
+description: "Survey to configure Windows feature management options"
+spec:
+  - question_name: "Reboot If Needed"
+    question_description: "Reboot the host automatically when a feature change requires it"
+    required: true
+    variable: "features_reboot"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Ignore Unknown Features"
+    question_description: "Ignore errors when removing features that are not valid on the host"
+    required: true
+    variable: "features_ignore_unknown"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"

--- a/roles/windows_manage_features/README.md
+++ b/roles/windows_manage_features/README.md
@@ -1,0 +1,40 @@
+# windows_manage_features
+
+Install and remove Windows Server roles and features.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_features_remove` | list(str) | `[]` | Windows feature names to remove (skipped if also in the install list) |
+| `windows_manage_features_remove_ignore_unknown` | bool | `true` | Ignore errors when removing features that are not valid on the host |
+| `windows_manage_features_install` | list(raw) | `[]` | Features to install; each item is a name string or a dict with `name` and optional `source`, `include_sub_features`, `include_management_tools` |
+| `windows_manage_features_reboot` | bool | `true` | Reboot automatically when a feature change requires it |
+
+## Example Playbook
+
+```yaml
+- name: Manage Windows features
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_features
+      vars:
+        windows_manage_features_remove:
+          - Telnet-Client
+        windows_manage_features_install:
+          - WoW64-Support
+          - name: Web-Server
+            source: D:\Sources
+            include_sub_features: true
+            include_management_tools: true
+        windows_manage_features_reboot: true
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_features/defaults/main.yml
+++ b/roles/windows_manage_features/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# Windows features to remove (list of feature name strings)
+windows_manage_features_remove: []
+
+# Ignore failures when removing features that are not valid on the host
+windows_manage_features_remove_ignore_unknown: true
+
+# Windows features to install.
+# Each item is either a feature name string, or a dictionary with a
+# 'name' key and optional 'source', 'include_sub_features', and
+# 'include_management_tools' keys.
+windows_manage_features_install: []
+
+# Reboot the host automatically when a feature change requires it
+windows_manage_features_reboot: true

--- a/roles/windows_manage_features/meta/argument_specs.yml
+++ b/roles/windows_manage_features/meta/argument_specs.yml
@@ -1,0 +1,36 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Manage Windows roles and features.
+    description:
+      - Install and remove Windows Server roles and features using
+        C(ansible.windows.win_feature).
+      - Optionally reboots the host when a feature change requires it.
+    options:
+      windows_manage_features_remove:
+        type: list
+        elements: str
+        description:
+          - List of Windows feature names to remove.
+          - Features also present in O(windows_manage_features_install) are skipped.
+        default: []
+      windows_manage_features_remove_ignore_unknown:
+        type: bool
+        description:
+          - Ignore errors when removing features that are not valid on the host.
+        default: true
+      windows_manage_features_install:
+        type: list
+        elements: raw
+        description:
+          - List of Windows features to install.
+          - Each item is either a feature name string, or a dictionary with a
+            C(name) key and optional C(source), C(include_sub_features), and
+            C(include_management_tools) keys.
+        default: []
+      windows_manage_features_reboot:
+        type: bool
+        description:
+          - Reboot the host automatically when a feature change requires it.
+        default: true

--- a/roles/windows_manage_features/meta/main.yml
+++ b/roles/windows_manage_features/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_features
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Install and remove Windows Server roles and features.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - features
+    - configuration
+dependencies: []

--- a/roles/windows_manage_features/tasks/main.yml
+++ b/roles/windows_manage_features/tasks/main.yml
@@ -1,0 +1,57 @@
+---
+- name: Remove unwanted Windows features
+  vars:
+    # Feature names being installed, so they are never removed in the same run.
+    windows_manage_features__installs: >-
+      {{ windows_manage_features_install | select('string') | list +
+         (windows_manage_features_install | selectattr('name', 'defined')
+          | map(attribute='name') | list) }}
+  ansible.windows.win_feature:
+    name: "{{ item }}"
+    state: absent
+  register: windows_manage_features__removed
+  failed_when:
+    - windows_manage_features__removed.msg is defined
+    - not windows_manage_features_remove_ignore_unknown | bool or
+      'name is not valid' not in windows_manage_features__removed.msg
+  loop: "{{ windows_manage_features_remove | reject('in', windows_manage_features__installs) }}"
+
+- name: Reboot after removing features
+  vars:
+    windows_manage_features__reboot_needed: "{{ windows_manage_features__removed.results
+                       | selectattr('reboot_required', 'defined')
+                       | selectattr('reboot_required', 'equalto', true)
+                       | list | length > 0 }}"
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: Ansible reboot after removing features
+  when:
+    - windows_manage_features_reboot | bool
+    - windows_manage_features__removed is changed
+    - windows_manage_features__reboot_needed | bool
+
+- name: Install wanted Windows features
+  ansible.windows.win_feature:
+    name: "{{ item if item is string else item.name }}"
+    source: "{{ item.source | default(omit) }}"
+    include_sub_features: "{{ item.include_sub_features | default(omit) }}"
+    include_management_tools: "{{ item.include_management_tools | default(omit) }}"
+    state: present
+  register: windows_manage_features__installed
+  loop: "{{ windows_manage_features_install }}"
+  loop_control:
+    label: "{{ item if item is string else item.name }}"
+
+- name: Reboot after installing features
+  vars:
+    windows_manage_features__reboot_needed: "{{ windows_manage_features__installed.results
+                       | selectattr('reboot_required', 'defined')
+                       | selectattr('reboot_required', 'equalto', true)
+                       | list | length > 0 }}"
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: Ansible reboot after installing features
+  when:
+    - windows_manage_features_reboot | bool
+    - windows_manage_features__installed is changed
+    - windows_manage_features__reboot_needed | bool

--- a/tests/integration/targets/windows_ops_test_windows_manage_features/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_features/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_features/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_features/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Telnet-Client is a safe, source-free feature that installs and removes
+# quickly without requiring a reboot, making it ideal for idempotency testing.
+windows_manage_features_test_feature: Telnet-Client

--- a/tests/integration/targets/windows_ops_test_windows_manage_features/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_features/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+- name: Test Windows feature management
+  block:
+    - name: Capture original feature state
+      ansible.windows.win_feature:
+        name: "{{ windows_manage_features_test_feature }}"
+        state: present
+      check_mode: true
+      register: windows_manage_features__orig
+
+    # -- State A: install the feature via the role --
+    - name: Install feature (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_features
+      vars:
+        windows_manage_features_install:
+          - "{{ windows_manage_features_test_feature }}"
+        windows_manage_features_reboot: false
+
+    - name: Verify feature is present after state A
+      ansible.windows.win_feature:
+        name: "{{ windows_manage_features_test_feature }}"
+        state: present
+      check_mode: true
+      register: windows_manage_features__verify_a
+
+    - name: Assert feature is present
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_features__verify_a.changed
+        fail_msg: "Feature {{ windows_manage_features_test_feature }} was not installed"
+        quiet: true
+
+    # -- Idempotency: re-run install, feature stays present with no change --
+    - name: Install feature again (idempotency)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_features
+      vars:
+        windows_manage_features_install:
+          - "{{ windows_manage_features_test_feature }}"
+        windows_manage_features_reboot: false
+
+    - name: Verify feature still present after idempotent re-run
+      ansible.windows.win_feature:
+        name: "{{ windows_manage_features_test_feature }}"
+        state: present
+      check_mode: true
+      register: windows_manage_features__verify_idempotent
+
+    - name: Assert role is idempotent
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_features__verify_idempotent.changed
+        fail_msg: "Feature {{ windows_manage_features_test_feature }} is not idempotent on re-run"
+        quiet: true
+
+    # -- State B: remove the feature via the role --
+    - name: Remove feature (state B)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_features
+      vars:
+        windows_manage_features_remove:
+          - "{{ windows_manage_features_test_feature }}"
+        windows_manage_features_reboot: false
+
+    - name: Verify feature is absent after state B
+      ansible.windows.win_feature:
+        name: "{{ windows_manage_features_test_feature }}"
+        state: present
+      check_mode: true
+      register: windows_manage_features__verify_b
+
+    - name: Assert feature is absent
+      ansible.builtin.assert:
+        that:
+          - windows_manage_features__verify_b.changed
+        fail_msg: "Feature {{ windows_manage_features_test_feature }} was not removed"
+        quiet: true
+
+  always:
+    - name: Restore feature to its original state
+      ansible.windows.win_feature:
+        name: "{{ windows_manage_features_test_feature }}"
+        state: "{{ 'absent' if windows_manage_features__orig.changed else 'present' }}"


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_features` role, migrated from the upstream `win_features` role in myllynen/windows-ansible-roles. Installs and removes Windows Server roles and features via `ansible.windows.win_feature`, with optional reboot handling.

Part of the ACA-2792 Windows content migration (Batch 6 — Packages/Features). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_features`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_features

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_features_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_features__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. Native `ansible.windows` only; no `win_powershell`. `ansible-lint --profile production` and `yamllint` pass clean.