### PR TITLE
feat(windows_manage_optional_features): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-optional-features.yml
+++ b/changelogs/fragments/add-windows-manage-optional-features.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_optional_features - new role for installing and removing Windows optional features via DISM, with optional reboot handling (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-optional-features.yml
+++ b/changelogs/fragments/add-windows-manage-optional-features.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "windows_manage_optional_features - new role for installing and removing Windows optional features via DISM, with optional reboot handling (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+  - "windows_manage_optional_features - new role for installing and removing Windows optional features via DISM, with optional reboot handling (https://github.com/redhat-cop/infra.windows_ops/pull/92)."

--- a/extensions/patterns/manage_optional_features/exec_env/README.md
+++ b/extensions/patterns/manage_optional_features/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_optional_features/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_optional_features/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_optional_features/exec_env/requirements.yml
+++ b/extensions/patterns/manage_optional_features/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_optional_features/playbooks/run_manage_optional_features.yml
+++ b/extensions/patterns/manage_optional_features/playbooks/run_manage_optional_features.yml
@@ -1,0 +1,14 @@
+---
+- name: Manage Windows Optional Features
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Manage optional features
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_optional_features
+      vars:
+        # Feature lists are supplied via extra_vars (surveys cannot collect lists):
+        #   windows_manage_optional_features_install, windows_manage_optional_features_remove
+        windows_manage_optional_features_reboot: "{{ optional_features_reboot | default(true) | bool }}"  # Set by survey
+        windows_manage_optional_features_remove_ignore_unknown: "{{ optional_features_ignore_unknown | default(true) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_optional_features/setup.yml
+++ b/extensions/patterns/manage_optional_features/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_optional_features_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_optional_features
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of Windows optional features.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of optional features.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Optional Features
+    description: >
+      This job template installs and removes Windows optional features, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_optional_features_pattern
+      - run_manage_optional_features
+    playbook: "extensions/patterns/manage_optional_features/playbooks/run_manage_optional_features.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_optional_features.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_optional_features/template_surveys/manage_optional_features.yml
+++ b/extensions/patterns/manage_optional_features/template_surveys/manage_optional_features.yml
@@ -1,0 +1,23 @@
+---
+name: "Manage Optional Features Survey"
+description: "Survey to control Windows optional feature reboot behavior. Feature lists are provided via extra_vars."
+spec:
+  - question_name: "Reboot If Needed"
+    question_description: "Reboot the host automatically when a feature change requires it"
+    required: true
+    variable: "optional_features_reboot"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Ignore Unknown On Removal"
+    question_description: "Ignore failures when removing features that are not present on the host"
+    required: true
+    variable: "optional_features_ignore_unknown"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"

--- a/roles/windows_manage_optional_features/README.md
+++ b/roles/windows_manage_optional_features/README.md
@@ -1,0 +1,39 @@
+# windows_manage_optional_features
+
+Install and remove Windows optional features via DISM, with optional automatic reboot.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_optional_features_remove` | list(str) | `[]` | Optional feature names to remove. Features also in the install list are skipped. |
+| `windows_manage_optional_features_remove_ignore_unknown` | bool | `true` | Ignore failures when removing features that are not present. |
+| `windows_manage_optional_features_install` | list(raw) | `[]` | Features to install. Each item is a name (string) or a mapping with `name` (required), `source`, `include_parent`. |
+| `windows_manage_optional_features_reboot` | bool | `true` | Reboot automatically when a change requires it. |
+
+## Example Playbook
+
+```yaml
+- name: Manage Windows optional features
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_optional_features
+      vars:
+        windows_manage_optional_features_remove:
+          - WindowsMediaPlayer
+        windows_manage_optional_features_install:
+          - TelnetClient
+          - name: IIS-WebServer
+            source: D:\Sources
+            include_parent: true
+        windows_manage_optional_features_reboot: true
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_optional_features/defaults/main.yml
+++ b/roles/windows_manage_optional_features/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# Windows optional feature names to remove
+windows_manage_optional_features_remove: []
+
+# Ignore failures when removing optional features that are not present
+windows_manage_optional_features_remove_ignore_unknown: true
+
+# Windows optional features to install.
+# Each item is either a feature name (string) or a mapping with keys:
+#   name (required), source, include_parent
+windows_manage_optional_features_install: []
+
+# Reboot automatically if a change requires it
+windows_manage_optional_features_reboot: true

--- a/roles/windows_manage_optional_features/meta/argument_specs.yml
+++ b/roles/windows_manage_optional_features/meta/argument_specs.yml
@@ -1,0 +1,34 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Manage Windows optional features.
+    description:
+      - Install and remove Windows optional features via DISM.
+      - Optionally reboots the host when a change requires it.
+    options:
+      windows_manage_optional_features_remove:
+        type: list
+        elements: str
+        description:
+          - List of Windows optional feature names to remove.
+          - Features also present in C(windows_manage_optional_features_install) are skipped.
+        default: []
+      windows_manage_optional_features_remove_ignore_unknown:
+        type: bool
+        description:
+          - Ignore failures when removing optional features that are not present on the host.
+        default: true
+      windows_manage_optional_features_install:
+        type: list
+        elements: raw
+        description:
+          - List of Windows optional features to install.
+          - Each item is either a feature name (string) or a mapping with C(name) (required)
+            and optionally C(source) and C(include_parent).
+        default: []
+      windows_manage_optional_features_reboot:
+        type: bool
+        description:
+          - Reboot the host automatically when installing or removing a feature requires it.
+        default: true

--- a/roles/windows_manage_optional_features/meta/main.yml
+++ b/roles/windows_manage_optional_features/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_optional_features
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Install and remove Windows optional features.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - features
+    - configuration
+dependencies: []

--- a/roles/windows_manage_optional_features/tasks/main.yml
+++ b/roles/windows_manage_optional_features/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+- name: Remove unwanted Windows optional features
+  vars:
+    windows_manage_optional_features__installs: >-
+      {{ (windows_manage_optional_features_install | select('string') | list)
+         + (windows_manage_optional_features_install | selectattr('name', 'defined')
+            | map(attribute='name') | list) }}
+  ansible.windows.win_optional_feature:
+    name: "{{ item }}"
+    state: absent
+  register: windows_manage_optional_features__removed
+  failed_when:
+    - windows_manage_optional_features__removed.msg is defined
+    - not windows_manage_optional_features_remove_ignore_unknown | bool or
+      'Failed to find' not in windows_manage_optional_features__removed.msg
+  loop: "{{ windows_manage_optional_features_remove
+            | reject('in', windows_manage_optional_features__installs) | list }}"
+
+- name: Reboot after removing optional features
+  vars:
+    windows_manage_optional_features__reboot_needed: >-
+      {{ windows_manage_optional_features__removed.results
+         | selectattr('reboot_required', 'defined')
+         | selectattr('reboot_required', 'equalto', true) | list | length > 0 }}
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: Ansible reboot after removing optional features
+  when:
+    - windows_manage_optional_features_reboot | bool
+    - windows_manage_optional_features__removed is changed
+    - windows_manage_optional_features__reboot_needed | bool
+
+- name: Install wanted Windows optional features
+  ansible.windows.win_optional_feature:
+    name: "{{ item if item is string else item.name }}"
+    source: "{{ item.source | default(omit) }}"
+    include_parent: "{{ item.include_parent | default(omit) }}"
+    state: present
+  register: windows_manage_optional_features__installed
+  loop: "{{ windows_manage_optional_features_install }}"
+  loop_control:
+    label: "{{ item if item is string else item.name }}"
+
+- name: Reboot after installing optional features
+  vars:
+    windows_manage_optional_features__reboot_needed: >-
+      {{ windows_manage_optional_features__installed.results
+         | selectattr('reboot_required', 'defined')
+         | selectattr('reboot_required', 'equalto', true) | list | length > 0 }}
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: Ansible reboot after installing optional features
+  when:
+    - windows_manage_optional_features_reboot | bool
+    - windows_manage_optional_features__installed is changed
+    - windows_manage_optional_features__reboot_needed | bool

--- a/tests/integration/targets/windows_ops_test_windows_manage_optional_features/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_optional_features/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_optional_features/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_optional_features/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# Candidate optional feature used by the test.
+# The test captures its original state and restores it in the always block.
+# If the feature is not available on the host image, the test skips gracefully.
+windows_manage_optional_features__test_candidate: TelnetClient

--- a/tests/integration/targets/windows_ops_test_windows_manage_optional_features/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_optional_features/tasks/main.yml
@@ -1,0 +1,95 @@
+---
+- name: Test Windows optional features management
+  block:
+    # Detect current state of the candidate feature (check_mode: changed => absent).
+    - name: Capture original state of candidate optional feature
+      ansible.windows.win_optional_feature:
+        name: "{{ windows_manage_optional_features__test_candidate }}"
+        state: present
+      check_mode: true
+      register: windows_manage_optional_features__orig
+      failed_when: false
+
+    - name: Record candidate availability and original state
+      ansible.builtin.set_fact:
+        windows_manage_optional_features__available: >-
+          {{ 'Failed to find' not in (windows_manage_optional_features__orig.msg | default('')) }}
+        windows_manage_optional_features__was_present: >-
+          {{ not (windows_manage_optional_features__orig.changed | default(true)) }}
+
+    - name: Run optional feature tests when the candidate is available
+      when: windows_manage_optional_features__available | bool
+      block:
+        # -- State A: install the candidate feature --
+        - name: Install candidate feature via role
+          ansible.builtin.include_role:
+            name: infra.windows_ops.windows_manage_optional_features
+          vars:
+            windows_manage_optional_features_install:
+              - "{{ windows_manage_optional_features__test_candidate }}"
+            windows_manage_optional_features_reboot: false
+
+        - name: Verify candidate feature is present
+          ansible.windows.win_optional_feature:
+            name: "{{ windows_manage_optional_features__test_candidate }}"
+            state: present
+          check_mode: true
+          register: windows_manage_optional_features__verify_present
+
+        - name: Assert candidate feature is installed
+          ansible.builtin.assert:
+            that:
+              - not windows_manage_optional_features__verify_present.changed
+            fail_msg: "Candidate optional feature was not installed"
+
+        # -- Idempotency --
+        - name: Install candidate feature again (idempotency)
+          ansible.builtin.include_role:
+            name: infra.windows_ops.windows_manage_optional_features
+          vars:
+            windows_manage_optional_features_install:
+              - "{{ windows_manage_optional_features__test_candidate }}"
+            windows_manage_optional_features_reboot: false
+
+        - name: Verify candidate feature still present after re-run
+          ansible.windows.win_optional_feature:
+            name: "{{ windows_manage_optional_features__test_candidate }}"
+            state: present
+          check_mode: true
+          register: windows_manage_optional_features__verify_idempotent
+
+        - name: Assert state unchanged after idempotent re-run
+          ansible.builtin.assert:
+            that:
+              - not windows_manage_optional_features__verify_idempotent.changed
+            fail_msg: "Role is not idempotent - candidate feature state changed on re-run"
+
+        # -- State B: remove the candidate feature --
+        - name: Remove candidate feature via role
+          ansible.builtin.include_role:
+            name: infra.windows_ops.windows_manage_optional_features
+          vars:
+            windows_manage_optional_features_remove:
+              - "{{ windows_manage_optional_features__test_candidate }}"
+            windows_manage_optional_features_reboot: false
+
+        - name: Verify candidate feature is absent
+          ansible.windows.win_optional_feature:
+            name: "{{ windows_manage_optional_features__test_candidate }}"
+            state: present
+          check_mode: true
+          register: windows_manage_optional_features__verify_absent
+
+        - name: Assert candidate feature was removed
+          ansible.builtin.assert:
+            that:
+              - windows_manage_optional_features__verify_absent.changed
+            fail_msg: "Candidate optional feature was not removed"
+
+  always:
+    - name: Restore candidate feature to its original state
+      ansible.windows.win_optional_feature:
+        name: "{{ windows_manage_optional_features__test_candidate }}"
+        state: "{{ 'present' if windows_manage_optional_features__was_present | bool else 'absent' }}"
+      when:
+        - windows_manage_optional_features__available | default(false) | bool


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_optional_features` role, migrated from the upstream `win_optional_features` role in myllynen/windows-ansible-roles. Enables and disables Windows optional features via `ansible.windows.win_optional_feature`, with optional reboot handling.

Part of the ACA-2792 Windows content migration (Batch 6 — Packages/Features). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_optional_features`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_optional_features

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_optional_features_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_optional_features__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. Native `ansible.windows` only; no `win_powershell`. `ansible-lint --profile production` and `yamllint` pass clean.