### PR TITLE
feat(windows_manage_dotnet): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-dotnet.yml
+++ b/changelogs/fragments/add-windows-manage-dotnet.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_dotnet - new role for optimizing .NET native images (ngen) for PowerShell and installed assemblies (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-dotnet.yml
+++ b/changelogs/fragments/add-windows-manage-dotnet.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "windows_manage_dotnet - new role for optimizing .NET native images (ngen) for PowerShell and installed assemblies (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+  - "windows_manage_dotnet - new role for optimizing .NET native images (ngen) for PowerShell and installed assemblies (https://github.com/redhat-cop/infra.windows_ops/pull/94)."

--- a/extensions/patterns/manage_dotnet/exec_env/README.md
+++ b/extensions/patterns/manage_dotnet/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_dotnet/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_dotnet/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_dotnet/exec_env/requirements.yml
+++ b/extensions/patterns/manage_dotnet/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_dotnet/playbooks/run_manage_dotnet.yml
+++ b/extensions/patterns/manage_dotnet/playbooks/run_manage_dotnet.yml
@@ -1,0 +1,12 @@
+---
+- name: Optimize Windows .NET Native Images
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Optimize .NET native images
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dotnet
+      vars:
+        windows_manage_dotnet_powershell: "{{ dotnet_powershell | default(true) | bool }}"  # Set by survey
+        windows_manage_dotnet_all_assemblies: "{{ dotnet_all_assemblies | default(false) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_dotnet/setup.yml
+++ b/extensions/patterns/manage_dotnet/setup.yml
@@ -1,0 +1,55 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_dotnet_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_dotnet
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of .NET
+      native image optimization. It organizes all necessary resources, including
+      playbooks, job templates, and surveys, to ensure seamless optimization of
+      .NET assemblies.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Dotnet
+    description: >
+      This job template optimizes .NET native images, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_dotnet_pattern
+      - run_manage_dotnet
+    playbook: "extensions/patterns/manage_dotnet/playbooks/run_manage_dotnet.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_dotnet.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_dotnet/template_surveys/manage_dotnet.yml
+++ b/extensions/patterns/manage_dotnet/template_surveys/manage_dotnet.yml
@@ -1,0 +1,23 @@
+---
+name: "Manage Dotnet Optimization Survey"
+description: "Survey to configure .NET native image optimization"
+spec:
+  - question_name: "Compile PowerShell Assemblies"
+    question_description: "Compile the PowerShell assemblies used by Ansible connections"
+    required: true
+    variable: "dotnet_powershell"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Compile All Assemblies"
+    question_description: "Compile all installed .NET assemblies (can take a long time)"
+    required: true
+    variable: "dotnet_all_assemblies"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"

--- a/roles/windows_manage_dotnet/README.md
+++ b/roles/windows_manage_dotnet/README.md
@@ -1,0 +1,39 @@
+# windows_manage_dotnet
+
+Optimize .NET native images (ngen) for PowerShell and installed assemblies.
+
+Compiling native images speeds up .NET/PowerShell startup, which improves the
+responsiveness of subsequent Ansible operations over WinRM/PowerShell.
+
+> **Note:** This is a maintenance action. The PowerShell-assembly step is
+> idempotent (it only compiles images that are pending or not installed);
+> compiling all assemblies may report `changed` while ngen processes its queue.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+- `community.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_dotnet_powershell` | bool | `true` | Compile the PowerShell assemblies used by Ansible connections |
+| `windows_manage_dotnet_all_assemblies` | bool | `false` | Compile all installed .NET assemblies (can be slow) |
+
+## Example Playbook
+
+```yaml
+- name: Optimize .NET native images
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_dotnet
+      vars:
+        windows_manage_dotnet_powershell: true
+        windows_manage_dotnet_all_assemblies: false
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_dotnet/defaults/main.yml
+++ b/roles/windows_manage_dotnet/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+# Compile the PowerShell .NET assemblies used by Ansible connections.
+# Improves the responsiveness of subsequent PowerShell/WinRM operations.
+windows_manage_dotnet_powershell: true
+
+# Compile all installed .NET assemblies (runs ngen for the whole machine).
+# This is thorough but can take a long time; disabled by default.
+windows_manage_dotnet_all_assemblies: false

--- a/roles/windows_manage_dotnet/meta/argument_specs.yml
+++ b/roles/windows_manage_dotnet/meta/argument_specs.yml
@@ -1,0 +1,23 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Optimize .NET native images on Windows hosts.
+    description:
+      - Compile .NET native images using ngen to improve runtime performance.
+      - Optionally compiles only the PowerShell assemblies used by Ansible
+        connections, all installed assemblies, or both.
+    options:
+      windows_manage_dotnet_powershell:
+        type: bool
+        description:
+          - Compile the PowerShell .NET assemblies used by Ansible connections.
+          - Improves the responsiveness of subsequent PowerShell/WinRM operations.
+        default: true
+      windows_manage_dotnet_all_assemblies:
+        type: bool
+        description:
+          - Compile all installed .NET assemblies by running ngen for the whole
+            machine.
+          - Thorough but can take a long time to complete.
+        default: false

--- a/roles/windows_manage_dotnet/meta/main.yml
+++ b/roles/windows_manage_dotnet/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_dotnet
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Optimize .NET native images (ngen) for PowerShell and installed assemblies.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - dotnet
+    - maintenance
+dependencies: []

--- a/roles/windows_manage_dotnet/tasks/main.yml
+++ b/roles/windows_manage_dotnet/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+# ansible.windows / community.windows provide no native module for selectively
+# compiling only the PowerShell .NET assemblies loaded for Ansible connections
+# (community.windows.win_dotnet_ngen compiles queued/all assemblies, not a
+# targeted subset). win_powershell is used here for that confirmed gap; it
+# reports its own changed state and honours check mode via $Ansible.CheckMode.
+- name: Compile PowerShell assemblies
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $Ansible.Changed = $false
+      # From https://docs.ansible.com/ansible/latest/os_guide/windows_performance.html
+      $ngenPath = [System.IO.Path]::Combine(
+        [Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory(), 'ngen.exe')
+      [AppDomain]::CurrentDomain.GetAssemblies() | ForEach-Object {
+        if (-not $_.Location) { return }
+        $name = Split-Path -Path $_.Location -Leaf
+        if ($name.StartsWith('Microsoft.PowerShell')) {
+          $images = & $ngenPath display $_.Location /nologo
+          if ($images -match 'pending' -or $images -match 'not installed') {
+            $Ansible.Changed = $true
+            if (-not $Ansible.CheckMode) {
+              & $ngenPath install $_.Location /nologo
+            }
+          }
+        }
+      }
+  when: windows_manage_dotnet_powershell | bool
+
+- name: Compile all installed assemblies
+  community.windows.win_dotnet_ngen:
+  when: windows_manage_dotnet_all_assemblies | bool

--- a/tests/integration/targets/windows_ops_test_windows_manage_dotnet/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_dotnet/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_dotnet/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_dotnet/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Test compiles only the PowerShell assemblies (fast, idempotent).
+# The all-assemblies path is intentionally left disabled to keep the run short.

--- a/tests/integration/targets/windows_ops_test_windows_manage_dotnet/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_dotnet/tasks/main.yml
@@ -1,0 +1,74 @@
+---
+# ngen native-image compilation is a system optimization with nothing to
+# restore afterwards, so there is no capture/cleanup phase. Idempotency is
+# verified functionally: after the role runs, no PowerShell assembly should
+# still be pending compilation.
+- name: Test .NET native image optimization
+  block:
+    - name: Optimize PowerShell assemblies (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dotnet
+      vars:
+        windows_manage_dotnet_powershell: true
+        windows_manage_dotnet_all_assemblies: false
+
+    - name: Probe for PowerShell assemblies still pending compilation
+      ansible.windows.win_powershell:
+        error_action: stop
+        script: |
+          $ngenPath = [System.IO.Path]::Combine(
+            [Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory(), 'ngen.exe')
+          $pending = 0
+          [AppDomain]::CurrentDomain.GetAssemblies() | ForEach-Object {
+            if (-not $_.Location) { return }
+            $name = Split-Path -Path $_.Location -Leaf
+            if ($name.StartsWith('Microsoft.PowerShell')) {
+              $images = & $ngenPath display $_.Location /nologo
+              if ($images -match 'pending' -or $images -match 'not installed') { $pending++ }
+            }
+          }
+          $Ansible.Result = $pending
+      check_mode: false
+      changed_when: false
+      register: windows_manage_dotnet__pending_after_a
+
+    - name: Assert all PowerShell assemblies are compiled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_dotnet__pending_after_a.result == 0
+        fail_msg: >-
+          {{ windows_manage_dotnet__pending_after_a.result }} PowerShell
+          assemblies were still pending after optimization.
+
+    - name: Re-run role to verify idempotency (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dotnet
+      vars:
+        windows_manage_dotnet_powershell: true
+        windows_manage_dotnet_all_assemblies: false
+
+    - name: Probe again after idempotent re-run
+      ansible.windows.win_powershell:
+        error_action: stop
+        script: |
+          $ngenPath = [System.IO.Path]::Combine(
+            [Runtime.InteropServices.RuntimeEnvironment]::GetRuntimeDirectory(), 'ngen.exe')
+          $pending = 0
+          [AppDomain]::CurrentDomain.GetAssemblies() | ForEach-Object {
+            if (-not $_.Location) { return }
+            $name = Split-Path -Path $_.Location -Leaf
+            if ($name.StartsWith('Microsoft.PowerShell')) {
+              $images = & $ngenPath display $_.Location /nologo
+              if ($images -match 'pending' -or $images -match 'not installed') { $pending++ }
+            }
+          }
+          $Ansible.Result = $pending
+      check_mode: false
+      changed_when: false
+      register: windows_manage_dotnet__pending_after_rerun
+
+    - name: Assert state remains stable after re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_dotnet__pending_after_rerun.result == 0
+        fail_msg: "PowerShell assemblies became pending again after a re-run."


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_dotnet` role, migrated from the upstream `dotnet_optimize` role in myllynen/windows-ansible-roles. Compiles .NET native images via `community.windows.win_dotnet_ngen` (all assemblies) and a targeted PowerShell-assembly optimization step.

Part of the ACA-2792 Windows content migration (Batch 6 — Packages/Features). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_dotnet`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_dotnet

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_dotnet_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_dotnet__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. `win_powershell` retained only for the targeted PowerShell-assembly optimization (a confirmed native-module gap; `win_dotnet_ngen` only compiles queued/all assemblies) and flagged with a comment; check mode handled via $Ansible.CheckMode. `ansible-lint --profile production` and `yamllint` pass clean.