### PR TITLE
feat(windows_manage_boot): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-boot.yml
+++ b/changelogs/fragments/add-windows-manage-boot.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_boot - new role for configuring Windows Boot Manager settings such as the boot menu timeout (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-boot.yml
+++ b/changelogs/fragments/add-windows-manage-boot.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "windows_manage_boot - new role for configuring Windows Boot Manager settings such as the boot menu timeout (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+  - "windows_manage_boot - new role for configuring Windows Boot Manager settings such as the boot menu timeout (https://github.com/redhat-cop/infra.windows_ops/pull/95)."

--- a/extensions/patterns/manage_boot/exec_env/README.md
+++ b/extensions/patterns/manage_boot/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_boot/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_boot/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_boot/exec_env/requirements.yml
+++ b/extensions/patterns/manage_boot/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_boot/playbooks/run_manage_boot.yml
+++ b/extensions/patterns/manage_boot/playbooks/run_manage_boot.yml
@@ -1,0 +1,11 @@
+---
+- name: Manage Windows Boot Configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Configure Boot Manager
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_boot
+      vars:
+        windows_manage_boot_timeout: "{{ boot_timeout | default(30) | int }}"  # Set by survey
+...

--- a/extensions/patterns/manage_boot/setup.yml
+++ b/extensions/patterns/manage_boot/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_boot_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_boot
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of boot configurations.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of Boot Manager settings.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Boot
+    description: >
+      This job template manages Boot Manager configurations, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_boot_pattern
+      - run_manage_boot
+    playbook: "extensions/patterns/manage_boot/playbooks/run_manage_boot.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_boot.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_boot/template_surveys/manage_boot.yml
+++ b/extensions/patterns/manage_boot/template_surveys/manage_boot.yml
@@ -1,0 +1,12 @@
+---
+name: "Manage Boot Configuration Survey"
+description: "Survey to configure Boot Manager options"
+spec:
+  - question_name: "Boot Menu Timeout"
+    question_description: "Boot Manager menu timeout in seconds (0-999)"
+    required: true
+    variable: "boot_timeout"
+    type: "integer"
+    min: 0
+    max: 999
+    default: 30

--- a/roles/windows_manage_boot/README.md
+++ b/roles/windows_manage_boot/README.md
@@ -1,0 +1,29 @@
+# windows_manage_boot
+
+Configure Windows Boot Manager settings such as the boot menu timeout.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_boot_timeout` | int | `30` | Boot Manager menu timeout in seconds (applied via `bcdedit /timeout` only when it differs from the current value) |
+
+## Example Playbook
+
+```yaml
+- name: Configure Windows boot settings
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_boot
+      vars:
+        windows_manage_boot_timeout: 10
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_boot/defaults/main.yml
+++ b/roles/windows_manage_boot/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Boot manager menu timeout in seconds
+windows_manage_boot_timeout: 30

--- a/roles/windows_manage_boot/meta/argument_specs.yml
+++ b/roles/windows_manage_boot/meta/argument_specs.yml
@@ -1,0 +1,16 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Configure Windows Boot Manager settings.
+    description:
+      - Configure Windows Boot Manager settings via C(bcdedit).
+      - Currently manages the boot menu timeout in seconds.
+    options:
+      windows_manage_boot_timeout:
+        type: int
+        description:
+          - Boot Manager menu timeout in seconds.
+          - The value is applied with C(bcdedit /timeout) only when it differs
+            from the current configuration.
+        default: 30

--- a/roles/windows_manage_boot/meta/main.yml
+++ b/roles/windows_manage_boot/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_boot
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Configure Windows Boot Manager settings such as the boot menu timeout.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - boot
+    - configuration
+dependencies: []

--- a/roles/windows_manage_boot/tasks/main.yml
+++ b/roles/windows_manage_boot/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- name: Validate boot timeout value
+  ansible.builtin.assert:
+    that:
+      - windows_manage_boot_timeout >= 0
+      - windows_manage_boot_timeout <= 999
+    quiet: true
+    fail_msg: >-
+      windows_manage_boot_timeout must be between 0 and 999 seconds,
+      got {{ windows_manage_boot_timeout }}.
+
+- name: Query current boot configuration
+  # bcdedit has no native module; win_command reads the current settings so the
+  # timeout is only changed when it actually differs (idempotency).
+  ansible.windows.win_command: bcdedit.exe /enum "{bootmgr}"
+  register: windows_manage_boot__bcdedit
+  changed_when: false
+  check_mode: false
+
+- name: Determine current boot timeout
+  # stdout_lines are trimmed and matched on a backslash-free pattern; a regex
+  # containing '\s' is unreliable inside a folded scalar (the escape is kept
+  # literal), so anchor on '^timeout' after trimming instead.
+  ansible.builtin.set_fact:
+    windows_manage_boot__current_timeout: >-
+      {{ (windows_manage_boot__bcdedit.stdout_lines
+          | map('trim')
+          | select('search', '^timeout')
+          | list | first | default('timeout -1'))
+         | split | last }}
+
+- name: Configure boot timeout
+  # argv/list form avoids any shell interpolation of the timeout value.
+  ansible.windows.win_command:
+    argv:
+      - bcdedit.exe
+      - /timeout
+      - "{{ windows_manage_boot_timeout | int }}"
+  when: windows_manage_boot__current_timeout | int != windows_manage_boot_timeout | int
+  changed_when: true

--- a/tests/integration/targets/windows_ops_test_windows_manage_boot/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_boot/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_boot/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_boot/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Test toggles the Boot Manager timeout to a safe, reversible value and
+# restores the original value afterwards. Changing the timeout cannot make
+# the host unbootable, and the test never reboots.

--- a/tests/integration/targets/windows_ops_test_windows_manage_boot/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_boot/tasks/main.yml
@@ -1,0 +1,97 @@
+---
+- name: Test Boot Manager configuration
+  block:
+    - name: Capture original boot configuration
+      ansible.windows.win_command: bcdedit.exe /enum "{bootmgr}"
+      register: windows_manage_boot__orig
+      changed_when: false
+
+    - name: Record original timeout and choose a distinct test value
+      ansible.builtin.set_fact:
+        windows_manage_boot__orig_timeout: >-
+          {{ (windows_manage_boot__orig.stdout_lines
+              | map('trim')
+              | select('search', '^timeout')
+              | list | first | default('timeout 30'))
+             | split | last }}
+
+    - name: Select a test timeout that differs from the original
+      ansible.builtin.set_fact:
+        windows_manage_boot__test_timeout: "{{ 20 if (windows_manage_boot__orig_timeout | int) == 15 else 15 }}"
+
+    # -- Apply the test value --
+    - name: Configure boot timeout (test value)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_boot
+      vars:
+        windows_manage_boot_timeout: "{{ windows_manage_boot__test_timeout | int }}"
+
+    - name: Read back boot configuration after change
+      ansible.windows.win_command: bcdedit.exe /enum "{bootmgr}"
+      register: windows_manage_boot__after
+      changed_when: false
+
+    - name: Extract timeout after change
+      ansible.builtin.set_fact:
+        windows_manage_boot__after_timeout: >-
+          {{ (windows_manage_boot__after.stdout_lines
+              | map('trim')
+              | select('search', '^timeout')
+              | list | first | default('timeout -1'))
+             | split | last }}
+
+    - name: Assert timeout was applied
+      ansible.builtin.assert:
+        that:
+          - windows_manage_boot__after_timeout | int == windows_manage_boot__test_timeout | int
+        fail_msg: >-
+          Expected timeout {{ windows_manage_boot__test_timeout }},
+          got {{ windows_manage_boot__after_timeout }}.
+
+    # -- Idempotency: re-run leaves the timeout at the test value --
+    - name: Configure boot timeout again (idempotency)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_boot
+      vars:
+        windows_manage_boot_timeout: "{{ windows_manage_boot__test_timeout | int }}"
+
+    - name: Read back boot configuration after idempotent re-run
+      ansible.windows.win_command: bcdedit.exe /enum "{bootmgr}"
+      register: windows_manage_boot__idempotent
+      changed_when: false
+
+    - name: Extract timeout after idempotent re-run
+      ansible.builtin.set_fact:
+        windows_manage_boot__idempotent_timeout: >-
+          {{ (windows_manage_boot__idempotent.stdout_lines
+              | map('trim')
+              | select('search', '^timeout')
+              | list | first | default('timeout -1'))
+             | split | last }}
+
+    - name: Assert role detected no change was needed on re-run
+      # The role exposes the timeout it read; if that equals the desired value
+      # the role's guard skipped the reconfigure - proving idempotency. With the
+      # broken extraction this fact was always -1, so this would have failed.
+      ansible.builtin.assert:
+        that:
+          - windows_manage_boot__current_timeout | int == windows_manage_boot__test_timeout | int
+        fail_msg: >-
+          Role is not idempotent - it read timeout
+          {{ windows_manage_boot__current_timeout }} instead of the applied
+          {{ windows_manage_boot__test_timeout }}, so it would reconfigure.
+
+    - name: Assert timeout unchanged after idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_boot__idempotent_timeout | int == windows_manage_boot__test_timeout | int
+        fail_msg: "Role is not idempotent - boot timeout drifted on re-run."
+
+  always:
+    - name: Restore original boot timeout
+      ansible.windows.win_command:
+        argv:
+          - bcdedit.exe
+          - /timeout
+          - "{{ windows_manage_boot__orig_timeout | int }}"
+      changed_when: false


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_boot` role, migrated from the upstream `boot_configuration` role in myllynen/windows-ansible-roles. Manages Windows boot settings (e.g. boot timeout) via `bcdedit` through `ansible.windows.win_command` in argv form.

Part of the ACA-2792 Windows content migration (Batch 7 — Maintenance/Config). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_boot`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_boot

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_boot_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_boot__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. No native bcdedit module exists, so `win_command` (argv form, no shell interpolation) is the correct primitive; no `win_powershell` used. `ansible-lint --profile production` and `yamllint` pass clean.