### PR TITLE
feat(windows_manage_disk_cleanup): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-disk-cleanup.yml
+++ b/changelogs/fragments/add-windows-manage-disk-cleanup.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "windows_manage_disk_cleanup - new role for reclaiming disk space by cleaning superseded Windows Update component files and clearing event logs (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+  - "windows_manage_disk_cleanup - new role for reclaiming disk space by cleaning superseded Windows Update component files and clearing event logs (https://github.com/redhat-cop/infra.windows_ops/pull/96)."

--- a/changelogs/fragments/add-windows-manage-disk-cleanup.yml
+++ b/changelogs/fragments/add-windows-manage-disk-cleanup.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_disk_cleanup - new role for reclaiming disk space by cleaning superseded Windows Update component files and clearing event logs (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/extensions/patterns/manage_disk_cleanup/exec_env/README.md
+++ b/extensions/patterns/manage_disk_cleanup/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_disk_cleanup/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_disk_cleanup/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_disk_cleanup/exec_env/requirements.yml
+++ b/extensions/patterns/manage_disk_cleanup/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_disk_cleanup/playbooks/run_manage_disk_cleanup.yml
+++ b/extensions/patterns/manage_disk_cleanup/playbooks/run_manage_disk_cleanup.yml
@@ -1,0 +1,13 @@
+---
+- name: Perform Windows Disk Cleanup
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Clean up disk space
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_disk_cleanup
+      vars:
+        windows_manage_disk_cleanup_windows_update_files: "{{ disk_cleanup_windows_update_files | default(false) | bool }}"  # Set by survey
+        windows_manage_disk_cleanup_windows_update_reset: "{{ disk_cleanup_windows_update_reset | default(false) | bool }}"  # Set by survey
+        windows_manage_disk_cleanup_event_logs: "{{ disk_cleanup_event_logs | default(false) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_disk_cleanup/setup.yml
+++ b/extensions/patterns/manage_disk_cleanup/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_disk_cleanup_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_disk_cleanup
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of disk cleanup operations.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of disk cleanup settings.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Disk Cleanup
+    description: >
+      This job template performs disk cleanup, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_disk_cleanup_pattern
+      - run_manage_disk_cleanup
+    playbook: "extensions/patterns/manage_disk_cleanup/playbooks/run_manage_disk_cleanup.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_disk_cleanup.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_disk_cleanup/template_surveys/manage_disk_cleanup.yml
+++ b/extensions/patterns/manage_disk_cleanup/template_surveys/manage_disk_cleanup.yml
@@ -1,0 +1,33 @@
+---
+name: "Manage Disk Cleanup Survey"
+description: "Survey to configure disk cleanup options"
+spec:
+  - question_name: "Clean Windows Update Files"
+    question_description: "Remove superseded Windows Update component files via DISM"
+    required: true
+    variable: "disk_cleanup_windows_update_files"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Reset Update Base"
+    question_description: "Also remove files needed to uninstall updates (irreversible; only applies when cleaning Windows Update files)"
+    required: true
+    variable: "disk_cleanup_windows_update_reset"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Clear Event Logs"
+    question_description: "Clear all Windows event log channels"
+    required: true
+    variable: "disk_cleanup_event_logs"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"

--- a/roles/windows_manage_disk_cleanup/README.md
+++ b/roles/windows_manage_disk_cleanup/README.md
@@ -1,0 +1,47 @@
+# windows_manage_disk_cleanup
+
+Reclaim disk space on Windows hosts by removing superseded Windows Update
+component files and optionally clearing Windows event logs.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_disk_cleanup_windows_update_files` | bool | `false` | Remove superseded Windows Update component files via DISM `/StartComponentCleanup` |
+| `windows_manage_disk_cleanup_windows_update_reset` | bool | `false` | Also remove files needed to uninstall updates (DISM `/ResetBase`, irreversible) |
+| `windows_manage_disk_cleanup_event_logs` | bool | `false` | Clear all Windows event log channels |
+
+All actions default to `false`, so running the role with no variables set makes
+no changes; enable only the cleanup steps you want.
+
+## Example Playbook
+
+```yaml
+- name: Clean up disk space
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_disk_cleanup
+      vars:
+        windows_manage_disk_cleanup_windows_update_files: true
+        windows_manage_disk_cleanup_windows_update_reset: false
+        windows_manage_disk_cleanup_event_logs: true
+```
+
+## Notes
+
+- **DISM component cleanup** is performed with `ansible.windows.win_command`.
+  It is a maintenance action with no queryable "already clean" state, so the
+  task always reports `changed` when it runs.
+- **Event log clearing** uses `ansible.windows.win_powershell`. No native
+  Ansible module can enumerate and clear every Windows event log channel, so
+  PowerShell (`EventLogSession`) is used for this step; the task honours check
+  mode and only reports `changed` when logs are actually cleared.
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_disk_cleanup/defaults/main.yml
+++ b/roles/windows_manage_disk_cleanup/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# Remove older (superseded) versions of Windows Update component files via DISM.
+windows_manage_disk_cleanup_windows_update_files: false
+
+# When removing Windows Update files, also remove the files needed to
+# uninstall previously installed updates (DISM /ResetBase). Irreversible.
+windows_manage_disk_cleanup_windows_update_reset: false
+
+# Clear all Windows event log channels.
+windows_manage_disk_cleanup_event_logs: false

--- a/roles/windows_manage_disk_cleanup/meta/argument_specs.yml
+++ b/roles/windows_manage_disk_cleanup/meta/argument_specs.yml
@@ -1,0 +1,29 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Perform Windows disk cleanup maintenance.
+    description:
+      - Reclaim disk space on Windows hosts by removing superseded Windows Update
+        component files and optionally clearing Windows event logs.
+    options:
+      windows_manage_disk_cleanup_windows_update_files:
+        type: bool
+        default: false
+        description:
+          - Remove older (superseded) versions of Windows Update component files
+            using DISM component cleanup (C(/StartComponentCleanup)).
+      windows_manage_disk_cleanup_windows_update_reset:
+        type: bool
+        default: false
+        description:
+          - When C(windows_manage_disk_cleanup_windows_update_files) is enabled,
+            also remove the files required to uninstall previously installed
+            updates (DISM C(/ResetBase)).
+          - "B(WARNING): This is irreversible; installed updates can no longer be
+            uninstalled afterwards."
+      windows_manage_disk_cleanup_event_logs:
+        type: bool
+        default: false
+        description:
+          - Clear all Windows event log channels.

--- a/roles/windows_manage_disk_cleanup/meta/main.yml
+++ b/roles/windows_manage_disk_cleanup/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_disk_cleanup
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Reclaim disk space by cleaning superseded Windows Update files and clearing event logs.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - maintenance
+    - cleanup
+dependencies: []

--- a/roles/windows_manage_disk_cleanup/tasks/main.yml
+++ b/roles/windows_manage_disk_cleanup/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+- name: Clean superseded Windows Update component files
+  vars:
+    windows_manage_disk_cleanup__reset_base: "{{ '/ResetBase' if windows_manage_disk_cleanup_windows_update_reset | bool else '' }}"
+  ansible.windows.win_command: >-
+    Dism.exe /Online /Quiet /Cleanup-Image /StartComponentCleanup
+    {{ windows_manage_disk_cleanup__reset_base }}
+  # DISM component cleanup is a maintenance action with no queryable "already
+  # clean" state, so the task is always reported as changed when it runs.
+  changed_when: true
+  when: windows_manage_disk_cleanup_windows_update_files | bool
+
+- name: Clear Windows event logs
+  # No native Ansible module can enumerate and clear every Windows event log
+  # channel, so win_powershell is used here (confirmed native-module gap).
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $Ansible.Changed = $false
+      $session = New-Object System.Diagnostics.Eventing.Reader.EventLogSession
+      foreach ($log in $session.GetLogNames()) {
+        try {
+          if (-not $Ansible.CheckMode) {
+            $session.ClearLog($log)
+          }
+          $Ansible.Changed = $true
+        } catch {
+          # Analytical/debug or read-only channels cannot be cleared; skip them.
+        }
+      }
+  when: windows_manage_disk_cleanup_event_logs | bool

--- a/tests/integration/targets/windows_ops_test_windows_manage_disk_cleanup/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_disk_cleanup/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_disk_cleanup/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_disk_cleanup/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Test verifies the safe no-op default and event log clearing against a
+# throwaway classic event log. The DISM component-cleanup step is left
+# disabled throughout: it is slow and irreversible, and is not needed to
+# validate the role's behaviour.
+windows_manage_disk_cleanup__test_log: AnsibleWinOpsDiskCleanupTest

--- a/tests/integration/targets/windows_ops_test_windows_manage_disk_cleanup/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_disk_cleanup/tasks/main.yml
@@ -1,0 +1,73 @@
+---
+- name: Test disk cleanup role
+  block:
+    - name: Create a throwaway classic event log and write an entry
+      ansible.windows.win_powershell:
+        error_action: stop
+        script: |
+          $log = '{{ windows_manage_disk_cleanup__test_log }}'
+          if (-not [System.Diagnostics.EventLog]::SourceExists($log)) {
+            New-EventLog -LogName $log -Source $log
+          }
+          Write-EventLog -LogName $log -Source $log -EntryType Information -EventId 1 -Message 'ansible windows_ops disk_cleanup test entry'
+
+    - name: Count entries in the test log before cleanup
+      ansible.windows.win_powershell:
+        script: |
+          $Ansible.Changed = $false
+          (Get-WinEvent -LogName '{{ windows_manage_disk_cleanup__test_log }}' -ErrorAction SilentlyContinue | Measure-Object).Count
+      register: windows_manage_disk_cleanup__precount
+
+    - name: Assert the test log was populated
+      ansible.builtin.assert:
+        that:
+          - windows_manage_disk_cleanup__precount.output[0] | int >= 1
+        fail_msg: "Test event log was not populated"
+
+    # -- No-op default: all cleanup actions disabled --
+    - name: Run role with defaults (all actions disabled)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_disk_cleanup
+
+    - name: Count entries after the no-op run
+      ansible.windows.win_powershell:
+        script: |
+          $Ansible.Changed = $false
+          (Get-WinEvent -LogName '{{ windows_manage_disk_cleanup__test_log }}' -ErrorAction SilentlyContinue | Measure-Object).Count
+      register: windows_manage_disk_cleanup__noop_count
+
+    - name: Assert the no-op default did not clear logs
+      ansible.builtin.assert:
+        that:
+          - windows_manage_disk_cleanup__noop_count.output[0] | int >= 1
+        fail_msg: "Disk cleanup cleared logs when event log clearing was disabled"
+
+    # -- Event log clearing enabled --
+    - name: Run role with event log clearing enabled
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_disk_cleanup
+      vars:
+        windows_manage_disk_cleanup_event_logs: true
+
+    - name: Count entries after clearing
+      ansible.windows.win_powershell:
+        script: |
+          $Ansible.Changed = $false
+          (Get-WinEvent -LogName '{{ windows_manage_disk_cleanup__test_log }}' -ErrorAction SilentlyContinue | Measure-Object).Count
+      register: windows_manage_disk_cleanup__postcount
+
+    - name: Assert event logs were cleared
+      ansible.builtin.assert:
+        that:
+          - windows_manage_disk_cleanup__postcount.output[0] | int == 0
+        fail_msg: "Event logs were not cleared when event log clearing was enabled"
+
+  always:
+    - name: Remove the throwaway event log
+      ansible.windows.win_powershell:
+        error_action: continue
+        script: |
+          $log = '{{ windows_manage_disk_cleanup__test_log }}'
+          if ([System.Diagnostics.EventLog]::SourceExists($log)) {
+            Remove-EventLog -LogName $log
+          }


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_disk_cleanup` role, migrated from the upstream `disk_cleanup` role in myllynen/windows-ansible-roles. Performs DISM component-store cleanup and optional event-log clearing.

Part of the ACA-2792 Windows content migration (Batch 7 — Maintenance/Config). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_disk_cleanup`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_disk_cleanup

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_disk_cleanup_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_disk_cleanup__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. `win_powershell` retained only for event-log clearing (no native module enumerates/clears every event channel), flagged with a comment; DISM cleanup uses native `win_command`. `ansible-lint --profile production` and `yamllint` pass clean.