### PR TITLE
feat(windows_manage_performance): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-performance.yml
+++ b/changelogs/fragments/add-windows-manage-performance.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "windows_manage_performance - new role for applying Windows performance tuning settings, including NTFS last access time, page file, power scheme, and hibernation (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+  - "windows_manage_performance - new role for applying Windows performance tuning settings, including NTFS last access time, page file, power scheme, and hibernation (https://github.com/redhat-cop/infra.windows_ops/pull/97)."

--- a/changelogs/fragments/add-windows-manage-performance.yml
+++ b/changelogs/fragments/add-windows-manage-performance.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_performance - new role for applying Windows performance tuning settings, including NTFS last access time, page file, power scheme, and hibernation (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/extensions/patterns/manage_performance/exec_env/README.md
+++ b/extensions/patterns/manage_performance/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_performance/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_performance/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_performance/exec_env/requirements.yml
+++ b/extensions/patterns/manage_performance/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_performance/playbooks/run_manage_performance.yml
+++ b/extensions/patterns/manage_performance/playbooks/run_manage_performance.yml
@@ -1,0 +1,17 @@
+---
+- name: Manage Windows Performance Settings
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Apply performance tuning
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_performance
+      vars:
+        windows_manage_performance_ntfs_last_access_time_update: >-
+          {{ performance_ntfs_last_access_time_update | default(false) | bool }}  # Set by survey
+        windows_manage_performance_page_file_size: "{{ performance_page_file_size | default('auto') }}"  # Set by survey
+        windows_manage_performance_page_file_reboot: >-
+          {{ performance_page_file_reboot | default(true) | bool }}  # Set by survey
+        windows_manage_performance_power_scheme: "{{ performance_power_scheme | default('balanced') }}"  # Set by survey
+        windows_manage_performance_hibernation: "{{ performance_hibernation | default(false) | bool }}"  # Set by survey
+...

--- a/extensions/patterns/manage_performance/setup.yml
+++ b/extensions/patterns/manage_performance/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_performance_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_performance
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of Windows performance settings.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of performance tuning.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Performance
+    description: >
+      This job template applies Windows performance tuning settings, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_performance_pattern
+      - run_manage_performance
+    playbook: "extensions/patterns/manage_performance/playbooks/run_manage_performance.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_performance.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_performance/template_surveys/manage_performance.yml
+++ b/extensions/patterns/manage_performance/template_surveys/manage_performance.yml
@@ -1,0 +1,51 @@
+---
+name: "Manage Performance Settings Survey"
+description: "Survey to configure Windows performance tuning options"
+spec:
+  - question_name: "NTFS Last Access Time Updates"
+    question_description: "Enable or disable NTFS last access time updates"
+    required: true
+    variable: "performance_ntfs_last_access_time_update"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Page File Size"
+    question_description: "Page file setting: auto, disabled, system, or a static size in MB (e.g. 4096)"
+    required: true
+    variable: "performance_page_file_size"
+    type: "text"
+    default: "auto"
+
+  - question_name: "Reboot After Page File Change"
+    question_description: "Reboot the host when a page file change requires it"
+    required: true
+    variable: "performance_page_file_reboot"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Power Scheme"
+    question_description: "Active power scheme to configure"
+    required: true
+    variable: "performance_power_scheme"
+    type: "multiplechoice"
+    choices:
+      - "balanced"
+      - "power_saver"
+      - "high_performance"
+    default: "balanced"
+
+  - question_name: "Hibernation"
+    question_description: "Enable or disable hibernation"
+    required: true
+    variable: "performance_hibernation"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"

--- a/roles/windows_manage_performance/README.md
+++ b/roles/windows_manage_performance/README.md
@@ -1,0 +1,47 @@
+# windows_manage_performance
+
+Apply common Windows performance tuning settings: NTFS last access time updates, page file configuration, the active power scheme, and hibernation.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+- `community.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_performance_ntfs_last_access_time_update` | bool | `false` | Enable or disable NTFS Last Access Time updates |
+| `windows_manage_performance_page_file_size` | str | `auto` | `auto`, `disabled`, `system`, or a static size in MB (e.g. `"4096"`) |
+| `windows_manage_performance_page_file_disk` | str | `C` | Drive letter hosting the page file (static/system managed) |
+| `windows_manage_performance_page_file_reboot` | bool | `true` | Reboot when a page file change requires it |
+| `windows_manage_performance_power_scheme` | str | `balanced` | Active power scheme: `balanced`, `power_saver`, or `high_performance` |
+| `windows_manage_performance_hibernation` | bool | `false` | Enable or disable hibernation |
+
+## Example Playbook
+
+```yaml
+- name: Tune Windows performance
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_performance
+      vars:
+        windows_manage_performance_ntfs_last_access_time_update: false
+        windows_manage_performance_page_file_size: auto
+        windows_manage_performance_power_scheme: high_performance
+        windows_manage_performance_hibernation: false
+```
+
+## Notes
+
+Windows power schemes and hibernation are managed through `powercfg.exe`. There
+is no native `ansible.windows`/`community.windows` module for these operations,
+so the role uses `ansible.windows.win_command` (read-only power scheme query)
+and `ansible.windows.win_powershell` (power scheme activation and hibernation
+toggle). Both PowerShell steps honour check mode and only report `changed` when
+the target state differs from the current state.
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_performance/defaults/main.yml
+++ b/roles/windows_manage_performance/defaults/main.yml
@@ -1,0 +1,25 @@
+---
+# Enable or disable NTFS Last Access Time updates
+windows_manage_performance_ntfs_last_access_time_update: false
+
+# Page file configuration
+# auto      - automatically managed
+# disabled  - page file fully disabled
+# <size>    - static page file size in MB (as a string, e.g. "4096")
+# system    - system managed page file size
+windows_manage_performance_page_file_size: auto
+
+# Disk drive letter to host the page file
+windows_manage_performance_page_file_disk: C
+
+# Reboot after a page file change when required
+windows_manage_performance_page_file_reboot: true
+
+# Power scheme configuration
+# balanced          - balance between performance and energy use
+# power_saver       - maximum energy savings at the cost of performance
+# high_performance  - maximum performance with higher energy use
+windows_manage_performance_power_scheme: balanced
+
+# Enable or disable hibernation
+windows_manage_performance_hibernation: false

--- a/roles/windows_manage_performance/meta/argument_specs.yml
+++ b/roles/windows_manage_performance/meta/argument_specs.yml
@@ -1,0 +1,49 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Apply Windows performance tuning settings.
+    description:
+      - Apply common Windows performance tuning settings.
+      - Manages NTFS last access time updates, the page file, the active power
+        scheme, and hibernation.
+    options:
+      windows_manage_performance_ntfs_last_access_time_update:
+        type: bool
+        description:
+          - Enable or disable NTFS Last Access Time updates.
+          - When C(false), last access time updates are disabled to reduce disk I/O.
+        default: false
+      windows_manage_performance_page_file_size:
+        type: str
+        description:
+          - Page file configuration.
+          - C(auto) lets Windows manage the page file automatically.
+          - C(disabled) fully disables the page file.
+          - C(system) uses a system managed page file size.
+          - Any other value is treated as a static page file size in MB (for example C("4096")).
+        default: auto
+      windows_manage_performance_page_file_disk:
+        type: str
+        description:
+          - Drive letter used to host the page file for static or system managed page files.
+        default: C
+      windows_manage_performance_page_file_reboot:
+        type: bool
+        description:
+          - Reboot the host when a page file change requires it to take effect.
+        default: true
+      windows_manage_performance_power_scheme:
+        type: str
+        description:
+          - Active power scheme to configure.
+        choices:
+          - balanced
+          - power_saver
+          - high_performance
+        default: balanced
+      windows_manage_performance_hibernation:
+        type: bool
+        description:
+          - Enable or disable hibernation.
+        default: false

--- a/roles/windows_manage_performance/meta/main.yml
+++ b/roles/windows_manage_performance/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_performance
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Apply Windows performance tuning settings (NTFS, page file, power scheme, hibernation).
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - performance
+    - configuration
+dependencies: []

--- a/roles/windows_manage_performance/tasks/main.yml
+++ b/roles/windows_manage_performance/tasks/main.yml
@@ -1,0 +1,115 @@
+---
+- name: Configure NTFS Last Access Time updates
+  ansible.windows.win_regedit:
+    path: HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem
+    name: NtfsDisableLastAccessUpdate
+    type: DWord
+    data: "{{ 0x80000000 if windows_manage_performance_ntfs_last_access_time_update else 0x80000001 }}"
+
+- name: Configure automatic page file setting
+  community.windows.win_pagefile:
+    automatic: "{{ windows_manage_performance_page_file_size == 'auto' }}"
+  register: windows_manage_performance__page_file_automatic
+
+- name: Reboot system after automatic page file change
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: "Ansible reboot after configuring page file"
+  when:
+    - windows_manage_performance_page_file_reboot
+    - windows_manage_performance__page_file_automatic is changed
+    - windows_manage_performance_page_file_size in ['auto', 'disabled', 'system']
+
+- name: Check page file configuration
+  community.windows.win_pagefile:
+  register: windows_manage_performance__page_file_status
+
+- name: Configure page file
+  vars:
+    windows_manage_performance__disable_page_file: "{{ windows_manage_performance_page_file_size == 'disabled' }}"
+    windows_manage_performance__static_page_file: "{{ windows_manage_performance_page_file_size
+      not in ['auto', 'disabled', 'system'] }}"
+    windows_manage_performance__page_file_state: "{{ 'query'
+      if windows_manage_performance_page_file_size == 'auto' else 'present' }}"
+    windows_manage_performance__override_needed: "{{ windows_manage_performance_page_file_size
+      not in ['auto', 'system'] and
+      (windows_manage_performance_page_file_size == 'disabled' or
+       (windows_manage_performance__page_file_status.pagefiles | length and
+        (windows_manage_performance_page_file_size
+         != windows_manage_performance__page_file_status.pagefiles[0].initial_size or
+         windows_manage_performance_page_file_size
+         != windows_manage_performance__page_file_status.pagefiles[0].maximum_size))) }}"
+    windows_manage_performance__static_to_system: "{{ windows_manage_performance_page_file_size == 'system' and
+      windows_manage_performance__page_file_status.pagefiles | length and
+      (windows_manage_performance__page_file_status.pagefiles[0].initial_size != 0 or
+       windows_manage_performance__page_file_status.pagefiles[0].maximum_size != 0) }}"
+  community.windows.win_pagefile:
+    state: "{{ 'absent' if windows_manage_performance__disable_page_file
+      else windows_manage_performance__page_file_state }}"
+    drive: "{{ windows_manage_performance_page_file_disk
+      if windows_manage_performance__static_page_file or
+      windows_manage_performance_page_file_size == 'system' else omit }}"
+    automatic: "{{ windows_manage_performance_page_file_size == 'auto' }}"
+    remove_all: "{{ windows_manage_performance__disable_page_file }}"
+    override: "{{ windows_manage_performance__override_needed or windows_manage_performance__static_to_system }}"
+    initial_size: "{{ windows_manage_performance_page_file_size | int
+      if windows_manage_performance__static_page_file else omit }}"
+    maximum_size: "{{ windows_manage_performance_page_file_size | int
+      if windows_manage_performance__static_page_file else omit }}"
+    system_managed: "{{ windows_manage_performance_page_file_size == 'system' }}"
+  register: windows_manage_performance__page_file_config
+
+- name: Reboot system after page file change
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: "Ansible reboot after configuring page file"
+  when:
+    - windows_manage_performance_page_file_reboot
+    - windows_manage_performance__page_file_config is changed
+
+# Windows power schemes are managed with powercfg.exe; there is no native
+# ansible.windows/community.windows module for querying or activating them,
+# so win_command (read-only) and win_powershell (activation) are used here.
+- name: Check current power scheme
+  check_mode: false
+  ansible.windows.win_command: powercfg.exe /list
+  register: windows_manage_performance__power_scheme_info
+  changed_when: false
+
+- name: Configure power scheme
+  vars:
+    windows_manage_performance__current_guid: "{{ ((windows_manage_performance__power_scheme_info.stdout_lines
+      | select('search', '\\*$'))[0] | split(' '))[3] }}"
+    windows_manage_performance__wanted_name: "{{ windows_manage_performance_power_scheme | replace('_', ' ') }}"
+    windows_manage_performance__wanted_guid: "{{ ((windows_manage_performance__power_scheme_info.stdout_lines
+      | select('search', windows_manage_performance__wanted_name, ignorecase=true))[0] | split(' '))[3] }}"
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $Ansible.Changed = $true
+      if ($Ansible.CheckMode) { return }
+      powercfg.exe /setactive {{ windows_manage_performance__wanted_guid }}
+  when: windows_manage_performance__current_guid != windows_manage_performance__wanted_guid
+
+# Hibernation is toggled with powercfg.exe /H, which likewise has no native
+# module; the script is idempotent by comparing the current HibernateEnabled
+# registry value before making a change.
+- name: Configure hibernation
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $Ansible.Changed = $false
+      $setting = {{ windows_manage_performance_hibernation | int }}
+      $current = (Get-ItemProperty HKLM:\SYSTEM\CurrentControlSet\Control\Power).HibernateEnabled
+      if ($setting -ne $current) {
+        $Ansible.Changed = $true
+        if ($Ansible.CheckMode) { return }
+        try {
+          $result = powercfg.exe /H {{ 'ON' if windows_manage_performance_hibernation else 'OFF' }} 2>&1
+        }
+        catch {
+          $Ansible.Result = $_.Exception.Message
+          $Ansible.Failed = $true
+          return
+        }
+      }

--- a/tests/integration/targets/windows_ops_test_windows_manage_performance/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_performance/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_performance/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_performance/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# The test asserts on the NTFS last access time registry value, which is
+# deterministic and safe to capture/restore. Page file, power scheme, and
+# hibernation are held at no-op values (auto / balanced / current hibernation
+# state) with reboot disabled so the test never disrupts the host or reboots.

--- a/tests/integration/targets/windows_ops_test_windows_manage_performance/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_performance/tasks/main.yml
@@ -1,0 +1,98 @@
+---
+- name: Test performance tuning configuration
+  block:
+    - name: Capture original NTFS last access time setting
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem
+        name: NtfsDisableLastAccessUpdate
+      register: windows_manage_performance__original_ntfs
+
+    - name: Capture original hibernation state
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Power
+        name: HibernateEnabled
+      register: windows_manage_performance__original_hibernate
+
+    - name: Record original values
+      ansible.builtin.set_fact:
+        windows_manage_performance__original_ntfs_data: "{{ windows_manage_performance__original_ntfs.value
+          | default(2147483649) }}"
+        windows_manage_performance__hibernation_current: "{{ (windows_manage_performance__original_hibernate.value
+          | default(0)) | int == 1 }}"
+
+    # -- State A: enable NTFS last access time updates (0x80000000) --
+    - name: Apply performance settings (state A - NTFS last access enabled)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_performance
+      vars:
+        windows_manage_performance_ntfs_last_access_time_update: true
+        windows_manage_performance_page_file_size: auto
+        windows_manage_performance_page_file_reboot: false
+        windows_manage_performance_power_scheme: balanced
+        windows_manage_performance_hibernation: "{{ windows_manage_performance__hibernation_current }}"
+
+    - name: Verify NTFS last access value after state A
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem
+        name: NtfsDisableLastAccessUpdate
+      register: windows_manage_performance__verify_a
+
+    - name: Assert NTFS last access updates enabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_performance__verify_a.value | int == 2147483648
+        fail_msg: "NTFS last access time updates were not enabled (expected 0x80000000)"
+
+    # -- Idempotency test --
+    - name: Re-run role to verify idempotency (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_performance
+      vars:
+        windows_manage_performance_ntfs_last_access_time_update: true
+        windows_manage_performance_page_file_size: auto
+        windows_manage_performance_page_file_reboot: false
+        windows_manage_performance_power_scheme: balanced
+        windows_manage_performance_hibernation: "{{ windows_manage_performance__hibernation_current }}"
+
+    - name: Verify NTFS last access value after idempotent re-run
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem
+        name: NtfsDisableLastAccessUpdate
+      register: windows_manage_performance__verify_idempotent
+
+    - name: Assert value unchanged after idempotent re-run
+      ansible.builtin.assert:
+        that:
+          - windows_manage_performance__verify_idempotent.value | int == 2147483648
+        fail_msg: "Role is not idempotent - NTFS last access value changed on re-run"
+
+    # -- State B: disable NTFS last access time updates (0x80000001) --
+    - name: Apply performance settings (state B - NTFS last access disabled)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_performance
+      vars:
+        windows_manage_performance_ntfs_last_access_time_update: false
+        windows_manage_performance_page_file_size: auto
+        windows_manage_performance_page_file_reboot: false
+        windows_manage_performance_power_scheme: balanced
+        windows_manage_performance_hibernation: "{{ windows_manage_performance__hibernation_current }}"
+
+    - name: Verify NTFS last access value after state B
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem
+        name: NtfsDisableLastAccessUpdate
+      register: windows_manage_performance__verify_b
+
+    - name: Assert NTFS last access updates disabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_performance__verify_b.value | int == 2147483649
+        fail_msg: "NTFS last access time updates were not disabled (expected 0x80000001)"
+
+  always:
+    - name: Restore original NTFS last access setting
+      ansible.windows.win_regedit:
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem
+        name: NtfsDisableLastAccessUpdate
+        type: DWord
+        data: "{{ windows_manage_performance__original_ntfs_data }}"


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_performance` role, migrated from the upstream `performance_tuning` role in myllynen/windows-ansible-roles. Applies performance tweaks: NTFS last-access via `ansible.windows.win_regedit`, page file via `community.windows.win_pagefile`, and power scheme/hibernation via `powercfg`.

Part of the ACA-2792 Windows content migration (Batch 7 — Maintenance/Config). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_performance`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_performance

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_performance_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_performance__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. Native `win_regedit`/`win_pagefile` used; `powercfg` power-scheme and hibernation steps retained as confirmed native gaps with comments. `ansible-lint --profile production` and `yamllint` pass clean.