### PR TITLE
feat(windows_manage_scheduled_tasks): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-scheduled-tasks.yml
+++ b/changelogs/fragments/add-windows-manage-scheduled-tasks.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_scheduled_tasks - new role for creating, enabling, disabling, and removing Windows scheduled tasks (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-scheduled-tasks.yml
+++ b/changelogs/fragments/add-windows-manage-scheduled-tasks.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "windows_manage_scheduled_tasks - new role for creating, enabling, disabling, and removing Windows scheduled tasks (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+  - "windows_manage_scheduled_tasks - new role for creating, enabling, disabling, and removing Windows scheduled tasks (https://github.com/redhat-cop/infra.windows_ops/pull/98)."

--- a/extensions/patterns/manage_scheduled_tasks/exec_env/README.md
+++ b/extensions/patterns/manage_scheduled_tasks/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_scheduled_tasks/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_scheduled_tasks/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_scheduled_tasks/exec_env/requirements.yml
+++ b/extensions/patterns/manage_scheduled_tasks/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_scheduled_tasks/playbooks/run_manage_scheduled_tasks.yml
+++ b/extensions/patterns/manage_scheduled_tasks/playbooks/run_manage_scheduled_tasks.yml
@@ -1,0 +1,15 @@
+---
+- name: Manage Windows Scheduled Tasks
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Configure scheduled tasks
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_scheduled_tasks
+      vars:
+        # The survey collects YAML/JSON lists as text; parse them into the
+        # role's list variables. The task definitions themselves are best
+        # supplied via job-template extra_vars for anything non-trivial.
+        windows_manage_scheduled_tasks_create: "{{ scheduled_tasks_create | from_yaml }}"  # Set by survey
+        windows_manage_scheduled_tasks_remove: "{{ scheduled_tasks_remove | from_yaml }}"  # Set by survey
+...

--- a/extensions/patterns/manage_scheduled_tasks/setup.yml
+++ b/extensions/patterns/manage_scheduled_tasks/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_scheduled_tasks_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_scheduled_tasks
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of scheduled tasks.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of Windows scheduled tasks.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage Scheduled Tasks
+    description: >
+      This job template manages Windows scheduled tasks, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_scheduled_tasks_pattern
+      - run_manage_scheduled_tasks
+    playbook: "extensions/patterns/manage_scheduled_tasks/playbooks/run_manage_scheduled_tasks.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_scheduled_tasks.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_scheduled_tasks/template_surveys/manage_scheduled_tasks.yml
+++ b/extensions/patterns/manage_scheduled_tasks/template_surveys/manage_scheduled_tasks.yml
@@ -1,0 +1,21 @@
+---
+name: "Manage Scheduled Tasks Survey"
+description: "Survey to create, enable, disable, or remove Windows scheduled tasks"
+spec:
+  - question_name: "Scheduled tasks to create"
+    question_description: >-
+      YAML or JSON list of scheduled task definitions passed to
+      win_scheduled_task. Each item requires a 'name'. Set 'enabled: false'
+      to create a disabled task. Use '[]' for none.
+    required: false
+    variable: "scheduled_tasks_create"
+    type: "textarea"
+    default: "[]"
+
+  - question_name: "Scheduled tasks to remove"
+    question_description: >-
+      YAML or JSON list of scheduled task names to remove. Use '[]' for none.
+    required: false
+    variable: "scheduled_tasks_remove"
+    type: "textarea"
+    default: "[]"

--- a/roles/windows_manage_scheduled_tasks/README.md
+++ b/roles/windows_manage_scheduled_tasks/README.md
@@ -1,0 +1,48 @@
+# windows_manage_scheduled_tasks
+
+Create, enable, disable, and remove Windows scheduled tasks.
+
+## Requirements
+
+- Ansible >= 2.18
+- `community.windows` collection
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_scheduled_tasks_create` | list(dict) | `[]` | Scheduled tasks to create, enable, or disable. Each item is passed to `community.windows.win_scheduled_task`; `name` is required. |
+| `windows_manage_scheduled_tasks_remove` | list(str) | `[]` | Scheduled task names to remove. A name also present in `windows_manage_scheduled_tasks_create` is skipped. |
+
+Each item in `windows_manage_scheduled_tasks_create` accepts the keys supported by
+the [`community.windows.win_scheduled_task`](https://docs.ansible.com/ansible/latest/collections/community/windows/win_scheduled_task_module.html)
+module (for example `actions`, `triggers`, `description`, `username`, `password`,
+`logon_type`, `run_level`, and `path`). Set `enabled: false` to create a disabled
+task; when `enabled` is omitted the task is enabled.
+
+## Example Playbook
+
+```yaml
+- name: Manage scheduled tasks
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_scheduled_tasks
+      vars:
+        windows_manage_scheduled_tasks_create:
+          - name: Report system info
+            description: Daily system info update
+            enabled: true
+            actions:
+              - path: cmd.exe
+                arguments: /c systeminfo.exe > \Windows\Temp\systeminfo.txt
+            triggers:
+              - type: daily
+                start_boundary: '2026-01-01T00:00:00'
+            username: SYSTEM
+        windows_manage_scheduled_tasks_remove:
+          - Obsoleted task
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_scheduled_tasks/defaults/main.yml
+++ b/roles/windows_manage_scheduled_tasks/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# List of scheduled task names to remove.
+# Uses community.windows.win_scheduled_task. A name present in
+# windows_manage_scheduled_tasks_create is skipped (create wins).
+windows_manage_scheduled_tasks_remove: []
+
+# List of scheduled tasks to create, enable, or disable.
+# Each item is a mapping passed to community.windows.win_scheduled_task;
+# 'name' is required. Set 'enabled: false' to create a disabled task.
+# See the role README for the full list of supported keys.
+windows_manage_scheduled_tasks_create: []

--- a/roles/windows_manage_scheduled_tasks/meta/argument_specs.yml
+++ b/roles/windows_manage_scheduled_tasks/meta/argument_specs.yml
@@ -1,0 +1,30 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Manage Windows scheduled tasks.
+    description:
+      - Create, enable, disable, and remove Windows scheduled tasks.
+      - Tasks are managed with the C(community.windows.win_scheduled_task) module.
+      - A task name listed for removal is skipped when the same name is also
+        present in C(windows_manage_scheduled_tasks_create).
+    options:
+      windows_manage_scheduled_tasks_remove:
+        type: list
+        elements: str
+        description:
+          - List of scheduled task names to remove.
+        default: []
+      windows_manage_scheduled_tasks_create:
+        type: list
+        elements: dict
+        description:
+          - List of scheduled tasks to create, enable, or disable.
+          - Each item is passed through to C(community.windows.win_scheduled_task).
+          - Each item must include C(name). Set C(enabled) to C(false) to create a
+            disabled task; when omitted the task is enabled.
+          - Common keys include C(actions), C(triggers), C(description),
+            C(username), C(password), C(logon_type), C(run_level), and C(path).
+            See the C(community.windows.win_scheduled_task) module documentation
+            for the complete list of supported keys.
+        default: []

--- a/roles/windows_manage_scheduled_tasks/meta/main.yml
+++ b/roles/windows_manage_scheduled_tasks/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_scheduled_tasks
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Create, enable, disable, and remove Windows scheduled tasks.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - scheduling
+    - configuration
+dependencies: []

--- a/roles/windows_manage_scheduled_tasks/tasks/main.yml
+++ b/roles/windows_manage_scheduled_tasks/tasks/main.yml
@@ -1,0 +1,51 @@
+---
+- name: Remove scheduled tasks
+  community.windows.win_scheduled_task:
+    name: "{{ item }}"
+    state: absent
+  loop: "{{ windows_manage_scheduled_tasks_remove }}"
+  when: item not in windows_manage_scheduled_tasks_create | map(attribute='name')
+
+- name: Configure scheduled tasks
+  # Enable/disable is driven per item by its 'enabled' key; when omitted the
+  # module default (enabled) applies, collapsing the upstream enabled/disabled
+  # split into a single idempotent task.
+  no_log: "{{ item.password is defined }}"
+  community.windows.win_scheduled_task:
+    name: "{{ item.name }}"
+    enabled: "{{ item.enabled | default(omit) }}"
+    date: "{{ item.date | default(omit) }}"
+    author: "{{ item.author | default(omit) }}"
+    version: "{{ item.version | default(omit) }}"
+    description: "{{ item.description | default(omit) }}"
+    display_name: "{{ item.display_name | default(omit) }}"
+    path: "{{ item.path | default(omit) }}"
+    source: "{{ item.source | default(omit) }}"
+    actions: "{{ item.actions | default(omit) }}"
+    triggers: "{{ item.triggers | default(omit) }}"
+    allow_demand_start: "{{ item.allow_demand_start | default(omit) }}"
+    allow_hard_terminate: "{{ item.allow_hard_terminate | default(omit) }}"
+    compatibility: "{{ item.compatibility | default(omit) }}"
+    delete_expired_task_after: "{{ item.delete_expired_task_after | default(omit) }}"
+    disallow_start_if_on_batteries: "{{ item.disallow_start_if_on_batteries | default(omit) }}"
+    stop_if_going_on_batteries: "{{ item.stop_if_going_on_batteries | default(omit) }}"
+    execution_time_limit: "{{ item.execution_time_limit | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
+    username: "{{ item.username | default(omit) }}"
+    password: "{{ item.password | default(omit) }}"
+    update_password: "{{ item.update_password | default(omit) }}"
+    hidden: "{{ item.hidden | default(omit) }}"
+    logon_type: "{{ item.logon_type | default(omit) }}"
+    multiple_instances: "{{ item.multiple_instances | default(omit) }}"
+    priority: "{{ item.priority | default(omit) }}"
+    restart_count: "{{ item.restart_count | default(omit) }}"
+    restart_interval: "{{ item.restart_interval | default(omit) }}"
+    run_level: "{{ item.run_level | default(omit) }}"
+    run_only_if_idle: "{{ item.run_only_if_idle | default(omit) }}"
+    run_only_if_network_available: "{{ item.run_only_if_network_available | default(omit) }}"
+    start_when_available: "{{ item.start_when_available | default(omit) }}"
+    wake_to_run: "{{ item.wake_to_run | default(omit) }}"
+    state: present
+  loop: "{{ windows_manage_scheduled_tasks_create }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/tests/integration/targets/windows_ops_test_windows_manage_scheduled_tasks/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_scheduled_tasks/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_scheduled_tasks/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_scheduled_tasks/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Test exercises create -> idempotency -> disable -> remove of a throwaway
+# scheduled task. The task is created under the root path and removed in the
+# always block, so it never persists on the host.

--- a/tests/integration/targets/windows_ops_test_windows_manage_scheduled_tasks/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_scheduled_tasks/tasks/main.yml
@@ -1,0 +1,112 @@
+---
+- name: Test windows_manage_scheduled_tasks
+  block:
+    - name: Define the throwaway test task
+      ansible.builtin.set_fact:
+        windows_manage_scheduled_tasks__test_name: _ansible_windows_ops_test_sched
+        windows_manage_scheduled_tasks__test_def:
+          - name: _ansible_windows_ops_test_sched
+            description: infra.windows_ops integration test task
+            enabled: true
+            actions:
+              - path: cmd.exe
+                arguments: /c exit
+            username: SYSTEM
+
+    # -- State A: create the task via the role --
+    - name: Create scheduled task via the role
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_scheduled_tasks
+      vars:
+        windows_manage_scheduled_tasks_create: "{{ windows_manage_scheduled_tasks__test_def }}"
+
+    - name: Stat the task after creation
+      community.windows.win_scheduled_task_stat:
+        name: "{{ windows_manage_scheduled_tasks__test_name }}"
+        path: \
+      register: windows_manage_scheduled_tasks__after_create
+
+    - name: Assert the task exists and is enabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_scheduled_tasks__after_create.task_exists
+          - windows_manage_scheduled_tasks__after_create.state.status != 'TASK_STATE_DISABLED'
+        fail_msg: "Scheduled task was not created or is not enabled"
+
+    # -- Idempotency: converge again, then confirm no drift in check mode --
+    - name: Re-run the role to converge again
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_scheduled_tasks
+      vars:
+        windows_manage_scheduled_tasks_create: "{{ windows_manage_scheduled_tasks__test_def }}"
+
+    - name: Verify the desired state is already present (check mode)
+      community.windows.win_scheduled_task:
+        name: "{{ windows_manage_scheduled_tasks__test_name }}"
+        enabled: true
+        actions:
+          - path: cmd.exe
+            arguments: /c exit
+        username: SYSTEM
+        state: present
+      check_mode: true
+      register: windows_manage_scheduled_tasks__idem
+
+    - name: Assert the role is idempotent
+      ansible.builtin.assert:
+        that:
+          - windows_manage_scheduled_tasks__idem is not changed
+        fail_msg: "Role is not idempotent - the task would change on re-run"
+
+    # -- State B: disable the task via the role --
+    - name: Disable scheduled task via the role
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_scheduled_tasks
+      vars:
+        windows_manage_scheduled_tasks_create:
+          - name: _ansible_windows_ops_test_sched
+            enabled: false
+            actions:
+              - path: cmd.exe
+                arguments: /c exit
+            username: SYSTEM
+
+    - name: Stat the task after disable
+      community.windows.win_scheduled_task_stat:
+        name: "{{ windows_manage_scheduled_tasks__test_name }}"
+        path: \
+      register: windows_manage_scheduled_tasks__after_disable
+
+    - name: Assert the task is disabled
+      ansible.builtin.assert:
+        that:
+          - windows_manage_scheduled_tasks__after_disable.task_exists
+          - windows_manage_scheduled_tasks__after_disable.state.status == 'TASK_STATE_DISABLED'
+        fail_msg: "Scheduled task was not disabled"
+
+    # -- Removal via the role --
+    - name: Remove scheduled task via the role
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_scheduled_tasks
+      vars:
+        windows_manage_scheduled_tasks_remove:
+          - _ansible_windows_ops_test_sched
+
+    - name: Stat the task after removal
+      community.windows.win_scheduled_task_stat:
+        name: "{{ windows_manage_scheduled_tasks__test_name }}"
+        path: \
+      register: windows_manage_scheduled_tasks__after_remove
+
+    - name: Assert the task is gone
+      ansible.builtin.assert:
+        that:
+          - not windows_manage_scheduled_tasks__after_remove.task_exists
+        fail_msg: "Scheduled task was not removed"
+
+  always:
+    - name: Clean up the throwaway test task
+      community.windows.win_scheduled_task:
+        name: _ansible_windows_ops_test_sched
+        path: \
+        state: absent


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_scheduled_tasks` role, migrated from the upstream `task_scheduling` role in myllynen/windows-ansible-roles. Creates, configures, and removes Windows scheduled tasks via `community.windows.win_scheduled_task`.

Part of the ACA-2792 Windows content migration (Batch 7 — Maintenance/Config). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_scheduled_tasks`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_scheduled_tasks

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_scheduled_tasks_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_scheduled_tasks__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. Native `community.windows` only; no `win_powershell`. Enabled/disabled configure paths collapsed into one task. `ansible-lint --profile production` and `yamllint` pass clean.