### PR TITLE
feat(windows_manage_dsc): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-dsc.yml
+++ b/changelogs/fragments/add-windows-manage-dsc.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "windows_manage_dsc - new role for applying Windows PowerShell DSC resource configurations with optional reboot handling (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+  - "windows_manage_dsc - new role for applying Windows PowerShell DSC resource configurations with optional reboot handling (https://github.com/redhat-cop/infra.windows_ops/pull/100)."

--- a/changelogs/fragments/add-windows-manage-dsc.yml
+++ b/changelogs/fragments/add-windows-manage-dsc.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_dsc - new role for applying Windows PowerShell DSC resource configurations with optional reboot handling (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/extensions/patterns/manage_dsc/exec_env/README.md
+++ b/extensions/patterns/manage_dsc/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_dsc/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_dsc/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_dsc/exec_env/requirements.yml
+++ b/extensions/patterns/manage_dsc/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_dsc/playbooks/run_manage_dsc.yml
+++ b/extensions/patterns/manage_dsc/playbooks/run_manage_dsc.yml
@@ -1,0 +1,20 @@
+---
+- name: Manage Windows DSC configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Apply DSC settings
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dsc
+      vars:
+        windows_manage_dsc_reboot: "{{ dsc_reboot | default(true) | bool }}"  # Set by survey
+        # windows_manage_dsc_settings is a list of mappings and cannot be represented
+        # by a survey question; supply it via job template extra variables, e.g.:
+        #   windows_manage_dsc_settings:
+        #     - setting: Create C:\Temp
+        #       resource_name: File
+        #       parameters:
+        #         DestinationPath: C:\Temp
+        #         Type: Directory
+        #         Ensure: Present
+...

--- a/extensions/patterns/manage_dsc/setup.yml
+++ b/extensions/patterns/manage_dsc/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_dsc_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_dsc
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of DSC configurations.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of DSC settings.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage DSC
+    description: >
+      This job template applies PowerShell DSC resource configurations, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_dsc_pattern
+      - run_manage_dsc
+    playbook: "extensions/patterns/manage_dsc/playbooks/run_manage_dsc.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_dsc.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_dsc/template_surveys/manage_dsc.yml
+++ b/extensions/patterns/manage_dsc/template_surveys/manage_dsc.yml
@@ -1,0 +1,14 @@
+---
+name: "Manage DSC Configuration Survey"
+description: "Survey to configure DSC options"
+spec:
+  - question_name: "Reboot After Changes"
+    question_description: >-
+      Reboot the host after DSC changes when a changed setting requests it.
+    required: true
+    variable: "dsc_reboot"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"

--- a/roles/windows_manage_dsc/README.md
+++ b/roles/windows_manage_dsc/README.md
@@ -1,0 +1,64 @@
+# windows_manage_dsc
+
+Apply Windows PowerShell Desired State Configuration (DSC) resource configurations with optional reboot handling.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+- PowerShell 5.0 or newer on the target host (required by `ansible.windows.win_dsc`)
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_dsc_settings` | list(dict) | `[]` | DSC resource configurations to apply |
+| `windows_manage_dsc_reboot` | bool | `true` | Reboot after DSC changes when a changed setting requests it |
+
+Each item in `windows_manage_dsc_settings` accepts:
+
+| Key | Type | Required | Description |
+|---|---|---|---|
+| `setting` | str | yes | Human-readable label shown in task output |
+| `resource_name` | str | yes | DSC resource to invoke (e.g. `Registry`, `File`, `Environment`) |
+| `parameters` | dict | yes | Mapping of DSC resource properties passed to `win_dsc` |
+| `reboot` | bool | no (`false`) | Whether a reboot is required after this setting changes |
+
+## Notes
+
+- The role uses the native `ansible.windows.win_dsc` module. Resource properties are
+  dynamic, so `parameters` is passed through with the task-level `args` keyword.
+- A few DSC resources (for example `Registry`, `File`, `Environment`, `Archive`,
+  `Script`) ship built in with PowerShell 5.0. Custom resources must be installed on
+  the target host separately.
+
+## Example Playbook
+
+```yaml
+- name: Apply DSC settings
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_dsc
+      vars:
+        windows_manage_dsc_reboot: true
+        windows_manage_dsc_settings:
+          - setting: Enable User Account Control (UAC)
+            resource_name: Registry
+            parameters:
+              Key: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System
+              ValueName: EnableLUA
+              ValueType: DWord
+              ValueData: 1
+              Ensure: Present
+            reboot: true
+          - setting: Create C:\Temp
+            resource_name: File
+            parameters:
+              DestinationPath: C:\Temp
+              Type: Directory
+              Ensure: Present
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_dsc/defaults/main.yml
+++ b/roles/windows_manage_dsc/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+# List of PowerShell DSC resource configurations to apply via
+# ansible.windows.win_dsc. Each item requires:
+#   setting:       a human-readable label (shown in task output)
+#   resource_name: the DSC resource to invoke (e.g. Registry, File, Environment)
+#   parameters:    a mapping of DSC resource properties
+# Optional per item:
+#   reboot:        whether a reboot is required after this setting changes
+#                  (only honored when windows_manage_dsc_reboot is true)
+windows_manage_dsc_settings: []
+
+# Reboot the host after DSC changes when a changed setting requests it.
+windows_manage_dsc_reboot: true

--- a/roles/windows_manage_dsc/meta/argument_specs.yml
+++ b/roles/windows_manage_dsc/meta/argument_specs.yml
@@ -1,0 +1,47 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Apply Windows PowerShell DSC resource configurations.
+    description:
+      - Apply one or more PowerShell Desired State Configuration (DSC) resources on
+        Windows hosts using M(ansible.windows.win_dsc).
+      - Optionally reboots the host when a changed setting requests it.
+    options:
+      windows_manage_dsc_settings:
+        type: list
+        elements: dict
+        description:
+          - List of DSC resource configurations to apply.
+        default: []
+        options:
+          setting:
+            type: str
+            required: true
+            description:
+              - A human-readable label for the DSC setting, shown in task output.
+          resource_name:
+            type: str
+            required: true
+            description:
+              - The name of the DSC resource to invoke (for example C(Registry),
+                C(File), or C(Environment)).
+          parameters:
+            type: dict
+            required: true
+            description:
+              - Mapping of DSC resource properties passed to M(ansible.windows.win_dsc).
+              - The exact keys depend on the DSC resource named in
+                O(windows_manage_dsc_settings[].resource_name).
+          reboot:
+            type: bool
+            default: false
+            description:
+              - Whether a reboot is required after this setting changes.
+              - Only honored when O(windows_manage_dsc_reboot) is C(true).
+      windows_manage_dsc_reboot:
+        type: bool
+        description:
+          - Reboot the host after DSC changes when a changed setting sets
+            O(windows_manage_dsc_settings[].reboot=true).
+        default: true

--- a/roles/windows_manage_dsc/meta/main.yml
+++ b/roles/windows_manage_dsc/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_dsc
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Apply Windows PowerShell DSC resource configurations with optional reboot handling.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - dsc
+    - configuration
+dependencies: []

--- a/roles/windows_manage_dsc/tasks/main.yml
+++ b/roles/windows_manage_dsc/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+- name: Validate DSC settings
+  ansible.builtin.assert:
+    that:
+      - item.parameters | length > 0
+    fail_msg: >-
+      DSC setting '{{ item.setting }}' must define a non-empty parameters mapping.
+    quiet: true
+  loop: "{{ windows_manage_dsc_settings }}"
+  loop_control:
+    label: "{{ item.setting }}"
+
+# The DSC resource properties are dynamic, so the parameters mapping is passed
+# through with the task-level "args" keyword (win_dsc has no fixed argument spec
+# for resource properties - see the module's free_form option).
+- name: Apply DSC settings
+  ansible.windows.win_dsc:
+    resource_name: "{{ item.resource_name }}"
+  args: "{{ item.parameters }}"
+  register: windows_manage_dsc__config
+  loop: "{{ windows_manage_dsc_settings }}"
+  loop_control:
+    label: "{{ item.setting }}"
+
+- name: Reboot system after DSC changes
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: Ansible reboot after DSC changes
+  when:
+    - windows_manage_dsc_reboot | bool
+    - windows_manage_dsc__config is changed
+    - windows_manage_dsc__config.results
+      | selectattr('item.reboot', 'defined')
+      | selectattr('item.reboot', 'equalto', true)
+      | selectattr('changed', 'equalto', true)
+      | length > 0

--- a/tests/integration/targets/windows_ops_test_windows_manage_dsc/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_dsc/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_dsc/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_dsc/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# Test applies the built-in Registry DSC resource to a throwaway key so no extra
+# DSC modules are required. The key is removed in the always block.

--- a/tests/integration/targets/windows_ops_test_windows_manage_dsc/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_dsc/tasks/main.yml
@@ -1,0 +1,91 @@
+---
+- name: Test windows_manage_dsc
+  vars:
+    windows_manage_dsc__test_key: HKLM:\SOFTWARE\_ansible_windows_ops_dsc_test
+    windows_manage_dsc__test_name: DscTestValue
+  block:
+    # -- State A: apply a throwaway registry value via the built-in Registry DSC resource --
+    - name: Apply DSC registry setting (state A)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dsc
+      vars:
+        windows_manage_dsc_reboot: false
+        windows_manage_dsc_settings:
+          - setting: Create throwaway DSC test value
+            resource_name: Registry
+            parameters:
+              Key: "{{ windows_manage_dsc__test_key }}"
+              ValueName: "{{ windows_manage_dsc__test_name }}"
+              ValueType: DWord
+              ValueData: 1
+              Ensure: Present
+
+    - name: Read back the DSC-applied value
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_dsc__test_key }}"
+        name: "{{ windows_manage_dsc__test_name }}"
+      register: windows_manage_dsc__verify_a
+
+    - name: Assert the value was applied
+      ansible.builtin.assert:
+        that:
+          - windows_manage_dsc__verify_a.exists
+          - windows_manage_dsc__verify_a.value == 1
+        fail_msg: "DSC did not apply the registry value"
+
+    # -- Idempotency: re-apply the identical setting --
+    - name: Apply DSC registry setting again (idempotency)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dsc
+      vars:
+        windows_manage_dsc_reboot: false
+        windows_manage_dsc_settings:
+          - setting: Create throwaway DSC test value
+            resource_name: Registry
+            parameters:
+              Key: "{{ windows_manage_dsc__test_key }}"
+              ValueName: "{{ windows_manage_dsc__test_name }}"
+              ValueType: DWord
+              ValueData: 1
+              Ensure: Present
+
+    - name: Assert idempotent re-run made no change
+      ansible.builtin.assert:
+        that:
+          - windows_manage_dsc__config is not changed
+        fail_msg: "windows_manage_dsc was not idempotent on re-run"
+
+    # -- State B: change the value to verify a second state applies --
+    - name: Apply DSC registry setting (state B - new value)
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_dsc
+      vars:
+        windows_manage_dsc_reboot: false
+        windows_manage_dsc_settings:
+          - setting: Update throwaway DSC test value
+            resource_name: Registry
+            parameters:
+              Key: "{{ windows_manage_dsc__test_key }}"
+              ValueName: "{{ windows_manage_dsc__test_name }}"
+              ValueType: DWord
+              ValueData: 2
+              Ensure: Present
+
+    - name: Read back the updated value
+      ansible.windows.win_reg_stat:
+        path: "{{ windows_manage_dsc__test_key }}"
+        name: "{{ windows_manage_dsc__test_name }}"
+      register: windows_manage_dsc__verify_b
+
+    - name: Assert the updated value was applied
+      ansible.builtin.assert:
+        that:
+          - windows_manage_dsc__verify_b.value == 2
+        fail_msg: "DSC did not update the registry value"
+
+  always:
+    - name: Remove throwaway DSC test registry key
+      ansible.windows.win_regedit:
+        path: "{{ windows_manage_dsc__test_key }}"
+        state: absent
+        delete_key: true


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_dsc` role, migrated from the upstream `dsc_settings` role in myllynen/windows-ansible-roles. Applies PowerShell DSC resources via the native `ansible.windows.win_dsc` module.

Part of the ACA-2792 Windows content migration (Batch 7 — Maintenance/Config). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_dsc`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_dsc

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_dsc_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_dsc__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. 100% native `ansible.windows.win_dsc`; no `win_powershell` (upstream never touched the LCM). `ansible-lint --profile production` and `yamllint` pass clean.