### PR TITLE
feat(windows_manage_wsl): add role for managing Windows content

### DIFF
--- a/changelogs/fragments/add-windows-manage-wsl.yml
+++ b/changelogs/fragments/add-windows-manage-wsl.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "windows_manage_wsl - new role for installing, configuring, and removing the Windows Subsystem for Linux (WSL) and its distributions (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."

--- a/changelogs/fragments/add-windows-manage-wsl.yml
+++ b/changelogs/fragments/add-windows-manage-wsl.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - "windows_manage_wsl - new role for installing, configuring, and removing the Windows Subsystem for Linux (WSL) and its distributions (https://github.com/redhat-cop/infra.windows_ops/pull/XXXX)."
+  - "windows_manage_wsl - new role for installing, configuring, and removing the Windows Subsystem for Linux (WSL) and its distributions (https://github.com/redhat-cop/infra.windows_ops/pull/101)."

--- a/extensions/patterns/manage_wsl/exec_env/README.md
+++ b/extensions/patterns/manage_wsl/exec_env/README.md
@@ -1,0 +1,8 @@
+Build EE manually, push to quay.io
+
+```
+ansible-builder build
+# podman build -f context/Containerfile -t ansible-execution-env:latest context
+podman tag ansible-execution-env:latest quay.io/redhat-cop/apd-ee-25-windows:latest
+podman push quay.io/redhat-cop/apd-ee-25-windows:latest
+```

--- a/extensions/patterns/manage_wsl/exec_env/execution-environment.yml
+++ b/extensions/patterns/manage_wsl/exec_env/execution-environment.yml
@@ -1,0 +1,11 @@
+---
+version: 3
+images:
+  base_image:
+    name: quay.io/ansible-product-demos/apd-ee-25:latest
+dependencies:
+  galaxy: requirements.yml
+  ansible_core:
+    package_pip: ansible-core
+  ansible_runner:
+    package_pip: ansible-runner

--- a/extensions/patterns/manage_wsl/exec_env/requirements.yml
+++ b/extensions/patterns/manage_wsl/exec_env/requirements.yml
@@ -1,0 +1,5 @@
+---
+collections:
+  - name: https://github.com/redhat-cop/infra.windows_ops.git
+    type: git
+    version: main

--- a/extensions/patterns/manage_wsl/playbooks/run_manage_wsl.yml
+++ b/extensions/patterns/manage_wsl/playbooks/run_manage_wsl.yml
@@ -1,0 +1,19 @@
+---
+- name: Manage Windows Subsystem for Linux (WSL)
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Configure WSL
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_wsl
+      vars:
+        windows_manage_wsl_enable: "{{ wsl_enable | default(true) | bool }}"  # Set by survey
+        windows_manage_wsl_update: "{{ wsl_update | default(false) | bool }}"  # Set by survey
+        windows_manage_wsl_reboot: "{{ wsl_reboot | default(true) | bool }}"  # Set by survey
+        windows_manage_wsl_distributions_exclusive: "{{ wsl_distributions_exclusive | default(false) | bool }}"  # Set by survey
+        windows_manage_wsl_config_file: "{{ wsl_config_file | default('') }}"  # Set by survey
+        windows_manage_wsl_distribution_default: "{{ wsl_distribution_default | default('') }}"  # Set by survey
+        # windows_manage_wsl_distributions and windows_manage_wsl_distributions_update
+        # are lists and windows_manage_wsl_distribution_update_commands is a dict;
+        # supply them via job-template extra_vars (surveys cannot collect lists/dicts).
+...

--- a/extensions/patterns/manage_wsl/setup.yml
+++ b/extensions/patterns/manage_wsl/setup.yml
@@ -1,0 +1,54 @@
+---
+# Labels
+#
+controller_labels:
+  - name: infra.windows_ops
+    organization: "{{ organization | default('Default') }}"
+  - name: manage_wsl_pattern
+    organization: "{{ organization | default('Default') }}"
+  - name: run_manage_wsl
+    organization: "{{ organization | default('Default') }}"
+
+# Execution Environments
+#
+controller_execution_environments:
+  - name: apd-ee-25-windows
+    description: Allow running Windows experience demo. Based on apd-ee-25.
+    image: quay.io/redhat-cop/apd-ee-25-windows:latest
+    pull: always
+
+# Projects
+#
+controller_projects:
+  - name: Windows Operations / Project
+    description: >
+      This project provides the foundation for automating the management of WSL configurations.
+      It organizes all necessary resources, including playbooks, job templates, and surveys, to ensure
+      seamless management of the Windows Subsystem for Linux.
+    organization: Default
+    scm_branch: main
+    scm_clean: false
+    scm_delete_on_update: false
+    scm_type: git
+    scm_update_on_launch: true
+    scm_url: https://github.com/redhat-cop/infra.windows_ops.git
+    credential: "{{ credential | default(omit, true) }}"
+
+
+# Job Templates
+#
+controller_templates:
+  - name: Windows Operations / Manage WSL
+    description: >
+      This job template manages WSL configurations, applying operational data as required.
+    ask_inventory_on_launch: true
+    labels:
+      - infra.windows_ops
+      - manage_wsl_pattern
+      - run_manage_wsl
+    playbook: "extensions/patterns/manage_wsl/playbooks/run_manage_wsl.yml"
+    project: Windows Operations / Project
+    survey_enabled: true
+    survey_spec: "{{ lookup('file', pattern.path.replace('setup.yml', '') + 'template_surveys/manage_wsl.yml') | from_yaml }}"
+    ask_credential_on_launch: true
+    execution_environment: apd-ee-25-windows

--- a/extensions/patterns/manage_wsl/template_surveys/manage_wsl.yml
+++ b/extensions/patterns/manage_wsl/template_surveys/manage_wsl.yml
@@ -1,0 +1,57 @@
+---
+name: "Manage WSL Configuration Survey"
+description: "Survey to configure Windows Subsystem for Linux (WSL) options"
+spec:
+  - question_name: "Enable WSL"
+    question_description: "Install (true) or uninstall (false) the Windows Subsystem for Linux"
+    required: true
+    variable: "wsl_enable"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Update WSL"
+    question_description: "Update WSL during configuration (no check-mode support)"
+    required: true
+    variable: "wsl_update"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Reboot After Changes"
+    question_description: "Reboot the host after a WSL install or uninstall"
+    required: true
+    variable: "wsl_reboot"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "true"
+
+  - question_name: "Exclusive Distributions"
+    question_description: "Remove installed distributions not in the supplied list"
+    required: true
+    variable: "wsl_distributions_exclusive"
+    type: "multiplechoice"
+    choices:
+      - "true"
+      - "false"
+    default: "false"
+
+  - question_name: "Config File Template"
+    question_description: "Template to install as %USERPROFILE%\\.wslconfig (e.g. disable_cgroup_v1); leave blank to skip"
+    required: false
+    variable: "wsl_config_file"
+    type: "text"
+    default: ""
+
+  - question_name: "Default Distribution"
+    question_description: "Distribution to set as default; leave blank to keep the current default"
+    required: false
+    variable: "wsl_distribution_default"
+    type: "text"
+    default: ""

--- a/roles/windows_manage_wsl/README.md
+++ b/roles/windows_manage_wsl/README.md
@@ -1,0 +1,52 @@
+# windows_manage_wsl
+
+Install, configure, and remove the Windows Subsystem for Linux (WSL) and its distributions.
+
+## Requirements
+
+- Ansible >= 2.18
+- `ansible.windows` collection
+- Windows Server 2022 or later
+
+## Notes
+
+WSL is managed through the `wsl.exe` CLI, for which there is no native
+`ansible.windows`/`community.windows` module. This role therefore uses
+`ansible.windows.win_powershell` for the `wsl.exe` operations (a confirmed
+native-module gap); each step reads current state first so the role stays
+idempotent. Installing or uninstalling WSL requires a reboot to complete, and
+installing distributions requires network access.
+
+## Role Variables
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `windows_manage_wsl_enable` | bool | `true` | Install (`true`) or uninstall (`false`) WSL |
+| `windows_manage_wsl_update` | bool | `false` | Update WSL during configuration (no check-mode support) |
+| `windows_manage_wsl_config_file` | str | `""` | Template to install as `%USERPROFILE%\.wslconfig` (empty = skip); the role ships `disable_cgroup_v1` |
+| `windows_manage_wsl_reboot` | bool | `true` | Reboot after a WSL install or uninstall |
+| `windows_manage_wsl_distributions` | list(str) | `[]` | Distributions to install |
+| `windows_manage_wsl_distributions_exclusive` | bool | `false` | Remove installed distributions not in the list above |
+| `windows_manage_wsl_distribution_default` | str | `""` | Distribution to set as default (empty = keep current) |
+| `windows_manage_wsl_distributions_update` | list(str) | install list | Distributions to update in place (no check-mode support) |
+| `windows_manage_wsl_distribution_update_commands` | dict | see `defaults/main.yml` | Per-variant update command mapping |
+
+## Example Playbook
+
+```yaml
+- name: Configure WSL
+  hosts: windows
+  roles:
+    - role: infra.windows_ops.windows_manage_wsl
+      vars:
+        windows_manage_wsl_enable: true
+        windows_manage_wsl_reboot: true
+        windows_manage_wsl_distributions:
+          - FedoraLinux-42
+        windows_manage_wsl_distribution_default: FedoraLinux-42
+        windows_manage_wsl_config_file: disable_cgroup_v1
+```
+
+## License
+
+GPL-3.0-or-later

--- a/roles/windows_manage_wsl/defaults/main.yml
+++ b/roles/windows_manage_wsl/defaults/main.yml
@@ -1,0 +1,58 @@
+---
+# Enable or disable WSL (Windows Subsystem for Linux).
+# Requires Windows Server 2022+.
+# NB. Distributions are installed for the connecting user.
+# Disabling WSL uninstalls all currently installed distributions
+# and the WSL feature.
+windows_manage_wsl_enable: true
+
+# Update WSL during configuration.
+# NB. This step does not support check mode; if enabled an update
+#     is always attempted.
+windows_manage_wsl_update: false
+
+# Config file template to install as %USERPROFILE%\.wslconfig.
+# Leave empty to skip managing the config file.
+# Role-provided alternative:
+#   * disable_cgroup_v1 - disable cgroup v1 completely
+windows_manage_wsl_config_file: ""
+
+# Reboot after WSL install or uninstall.
+# NB. A reboot is mandatory to complete un/install and later steps
+#     will fail before rebooting.
+windows_manage_wsl_reboot: true
+
+# List of distributions to install.
+# See "wsl.exe --list --online" for alternatives, e.g. FedoraLinux-42.
+windows_manage_wsl_distributions: []
+
+# Remove distributions not listed in windows_manage_wsl_distributions.
+windows_manage_wsl_distributions_exclusive: false
+
+# Default WSL distribution. Leave empty to keep the current default.
+windows_manage_wsl_distribution_default: ""
+
+# List of distributions to update.
+# Defaults to the install list (windows_manage_wsl_distributions).
+# NB. This step does not support check mode; if a distribution is
+#     listed an update is always attempted.
+windows_manage_wsl_distributions_update: "{{ windows_manage_wsl_distributions }}"
+
+# Update commands for each distribution variant.
+# Patterns are case-insensitive; the first match is used.
+windows_manage_wsl_distribution_update_commands:
+  arch_like:
+    patterns: ['*archlinux*']
+    commands: ['pacman -Syyu --noconfirm']
+  debian_like:
+    patterns: ['*Debian*', '*kali*', '*Ubuntu*']
+    commands: ['apt-get update', 'apt-get upgrade -y']
+  redhat_like:
+    patterns: ['*Alma*', '*CentOS*', '*Fedora*', '*Oracle*', '*podman*', '*RHEL*']
+    commands: ['dnf --refresh -y upgrade']
+  suse_like:
+    patterns: ['*SUSE*']
+    commands: ['zypper update -y']
+  default:
+    patterns: ['*']
+    commands: ['/bin/true']

--- a/roles/windows_manage_wsl/meta/argument_specs.yml
+++ b/roles/windows_manage_wsl/meta/argument_specs.yml
@@ -1,0 +1,70 @@
+---
+argument_specs:
+  main:
+    version_added: 2.1.0
+    short_description: Configure the Windows Subsystem for Linux (WSL).
+    description:
+      - Install or uninstall the Windows Subsystem for Linux (WSL) on Windows hosts.
+      - Manages the C(.wslconfig) configuration file, installed distributions, the
+        default distribution, and in-distribution package updates.
+      - Requires Windows Server 2022 or later.
+    options:
+      windows_manage_wsl_enable:
+        type: bool
+        description:
+          - Enable (install) or disable (uninstall) WSL.
+          - Disabling WSL uninstalls all installed distributions and the WSL feature.
+        default: true
+      windows_manage_wsl_update:
+        type: bool
+        description:
+          - Update WSL during configuration.
+          - This step does not support check mode; when enabled an update is always attempted.
+        default: false
+      windows_manage_wsl_config_file:
+        type: str
+        description:
+          - Template to install as C(%USERPROFILE%\.wslconfig).
+          - Leave empty to skip managing the configuration file.
+          - The role provides the C(disable_cgroup_v1) alternative.
+        default: ""
+      windows_manage_wsl_reboot:
+        type: bool
+        description:
+          - Reboot the host after a WSL install or uninstall.
+          - A reboot is mandatory to complete un/install; later steps fail before rebooting.
+        default: true
+      windows_manage_wsl_distributions:
+        type: list
+        elements: str
+        description:
+          - Distributions to install. See C(wsl.exe --list --online) for alternatives.
+        default: []
+      windows_manage_wsl_distributions_exclusive:
+        type: bool
+        description:
+          - Remove any installed distribution not listed in
+            O(windows_manage_wsl_distributions).
+        default: false
+      windows_manage_wsl_distribution_default:
+        type: str
+        description:
+          - Distribution to set as the default. Leave empty to keep the current default.
+        default: ""
+      windows_manage_wsl_distributions_update:
+        type: list
+        elements: str
+        description:
+          - Distributions to update in place.
+          - Defaults to the value of O(windows_manage_wsl_distributions).
+          - This step does not support check mode; when a distribution is listed an
+            update is always attempted.
+        default: []
+      windows_manage_wsl_distribution_update_commands:
+        type: dict
+        description:
+          - Mapping of distribution variants to the shell commands used to update them.
+          - Each entry provides a list of C(patterns) (case-insensitive globs matched
+            against the distribution name) and a list of C(commands) to run.
+          - The first matching variant is used.
+        default: {}

--- a/roles/windows_manage_wsl/meta/main.yml
+++ b/roles/windows_manage_wsl/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  role_name: windows_manage_wsl
+  author: Hen Yaish
+  company: Red Hat, Inc.
+  description: Install, configure, and remove the Windows Subsystem for Linux (WSL) and its distributions.
+  license: GPL-3.0-or-later
+  min_ansible_version: "2.18"
+  platforms:
+    - name: Windows
+      versions:
+        - "2019"
+        - "2022"
+        - "2025"
+  galaxy_tags:
+    - windows
+    - wsl
+    - configuration
+dependencies: []

--- a/roles/windows_manage_wsl/tasks/disable.yml
+++ b/roles/windows_manage_wsl/tasks/disable.yml
@@ -1,0 +1,54 @@
+---
+# As in enable.yml, wsl.exe has no native module; ansible.windows.win_powershell
+# is used for the uninstall (a confirmed native-module gap). The task reads
+# current state first and only makes changes when WSL is present, and honours
+# --check via the ansible_check_mode play variable.
+- name: Uninstall WSL (Windows Subsystem for Linux)
+  environment:
+    WSL_UTF8: "1"
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: silently_continue
+    script: |
+      $Ansible.Changed = $false
+      $status = (wsl.exe --status) -replace '\x00', '' | ? { $_ -ne '' } | Out-String
+      if ($status -and $status -notmatch 'not found|not installed') {
+        $Ansible.Changed = $true
+        if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+        (wsl.exe --shutdown) -replace '\x00', '' | ? { $_ -ne '' } | Out-String
+        foreach ($distro in @((wsl.exe --list --all --quiet) -replace '\x00', '' | ? { $_ -ne '' })) {
+          (wsl.exe --unregister "$distro") -replace '\x00', '' | ? { $_ -ne '' } | Out-String
+        }
+        $result = (wsl.exe --uninstall) -replace '\x00', '' | ? { $_ -ne '' } | Out-String
+        if ($LASTEXITCODE -ne 0) {
+          $Ansible.Result = "Failed to uninstall WSL: $result"
+          $Ansible.Failed = $true
+          Exit 1
+        }
+      }
+      $feature = Get-WindowsOptionalFeature -FeatureName Microsoft-Windows-Subsystem-Linux -Online | ? State -eq 'Enabled'
+      if ($feature) {
+        $Ansible.Changed = $true
+        if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+        $disable = Disable-WindowsOptionalFeature -FeatureName Microsoft-Windows-Subsystem-Linux -NoRestart -Online
+        if (-not $disable) {
+          $Ansible.Result = "Failed to disable WSL feature: $disable"
+          $Ansible.Failed = $true
+          Exit 1
+        }
+      }
+  register: windows_manage_wsl__uninstall
+
+- name: Remove WSL configuration file
+  ansible.windows.win_file:
+    path: '%USERPROFILE%\.wslconfig'
+    state: absent
+  when: windows_manage_wsl_config_file is truthy
+
+- name: Reboot system
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: "Ansible reboot after WSL changes"
+  when:
+    - windows_manage_wsl_reboot | bool
+    - windows_manage_wsl__uninstall is changed

--- a/roles/windows_manage_wsl/tasks/enable.yml
+++ b/roles/windows_manage_wsl/tasks/enable.yml
@@ -1,0 +1,193 @@
+---
+# WSL is managed through the wsl.exe CLI, for which there is no native
+# ansible.windows/community.windows module. ansible.windows.win_powershell is
+# therefore used for the wsl.exe operations below (a confirmed native-module
+# gap). Each task reads current state first and only reports/makes changes when
+# needed, so the role stays idempotent. The read tasks set check_mode: false so
+# they always execute, and consult the ansible_check_mode play variable to
+# decide whether to make actual changes under --check.
+- name: Install WSL (Windows Subsystem for Linux)
+  environment:
+    WSL_UTF8: "1"
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: silently_continue
+    script: |
+      $Ansible.Changed = $false
+      $status = (wsl.exe --status) -replace '\x00', '' | ? { $_ -ne '' } | Out-String
+      if ($LASTEXITCODE -ne 0) {
+        $Ansible.Changed = $true
+        if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+        $opts = if ($status -match 'not found') { '--update' } else { '--install', '--no-distribution' }
+        # Start-Process here is required at least with Windows Server 2025
+        $result = Start-Process -FilePath wsl.exe -ArgumentList "$opts" -PassThru -Verb RunAs -Wait
+        if ($result.ExitCode -ne 0) {
+          $Ansible.Result = "Failed to install WSL: $result"
+          $Ansible.Failed = $true
+          Exit 1
+        }
+      }
+  register: windows_manage_wsl__install
+
+- name: Update WSL (Windows Subsystem for Linux)
+  environment:
+    WSL_UTF8: "1"
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: silently_continue
+    script: |
+      $Ansible.Changed = $false
+      $result = (wsl.exe --update) -replace '\x00', '' | ? { $_ -ne '' } | Out-String
+      $rc = $LASTEXITCODE
+      if ($result -notmatch 'already installed') {
+        $Ansible.Changed = $true
+      }
+      if ($rc -ne 0) {
+        $Ansible.Result = "Failed to update WSL: $result"
+        $Ansible.Failed = $true
+        Exit 1
+      }
+  when:
+    - windows_manage_wsl_update | bool
+    - windows_manage_wsl__install is not changed
+
+- name: Create WSL configuration file
+  ansible.windows.win_template:
+    src: "{{ windows_manage_wsl_config_file }}"
+    dest: '%USERPROFILE%\.wslconfig'
+    newline_sequence: '\r\n'
+  when: windows_manage_wsl_config_file is truthy
+
+- name: Reboot system
+  ansible.windows.win_reboot:
+    reboot_timeout: 600
+    msg: "Ansible reboot after WSL changes"
+  when:
+    - windows_manage_wsl_reboot | bool
+    - windows_manage_wsl__install is changed
+
+- name: Check installed WSL distributions
+  environment:
+    WSL_UTF8: "1"
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: stop
+    script: |
+      $Ansible.Changed = $false
+      $Ansible.Result = @((wsl.exe --list --quiet) -replace '\x00', '' | ? { $_ -ne '' })
+  register: windows_manage_wsl__distros
+  retries: 10
+  delay: 3
+  until: windows_manage_wsl__distros is not failed
+  when:
+    - windows_manage_wsl_distributions is truthy or
+      windows_manage_wsl_distributions_exclusive | bool
+
+- name: Uninstall WSL distributions
+  environment:
+    WSL_UTF8: "1"
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: silently_continue
+    script: |
+      $Ansible.Changed = $false
+      $current = @((wsl.exe --list --quiet) -replace '\x00', '' | ? { $_ -ne '' })
+      if ($current -contains '{{ item }}') {
+        $Ansible.Changed = $true
+        if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+        (wsl.exe --terminate '{{ item }}') -replace '\x00', '' | ? { $_ -ne '' } | Out-String
+        $result = (wsl.exe --unregister '{{ item }}') -replace '\x00', '' | ? { $_ -ne '' } | Out-String
+        if ($LASTEXITCODE -ne 0) {
+          $Ansible.Result = "Failed to uninstall '{{ item }}': $result"
+          $Ansible.Failed = $true
+          Exit 1
+        }
+      }
+  loop: "{{ windows_manage_wsl__distros.result }}"
+  when:
+    - windows_manage_wsl_distributions_exclusive | bool
+    - item not in windows_manage_wsl_distributions
+
+- name: Install WSL distributions
+  environment:
+    WSL_UTF8: "1"
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: silently_continue
+    script: |
+      $Ansible.Changed = $false
+      $current = @((wsl.exe --list --quiet) -replace '\x00', '' | ? { $_ -ne '' })
+      if ($current -notcontains '{{ item }}') {
+        $Ansible.Changed = $true
+        if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+        $result = (wsl.exe --install '{{ item }}' --no-launch) -replace '\x00', '' | ? { $_ -ne '' } | Out-String
+        if ($LASTEXITCODE -ne 0) {
+          $Ansible.Result = "Failed to install '{{ item }}': $result"
+          $Ansible.Failed = $true
+          Exit 1
+        }
+      }
+  loop: "{{ windows_manage_wsl_distributions }}"
+  when: item not in windows_manage_wsl__distros.result
+
+- name: Configure WSL default distribution
+  environment:
+    WSL_UTF8: "1"
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: silently_continue
+    script: |
+      $Ansible.Changed = $false
+      $current = @((wsl.exe --status) -replace '\x00', '' | ? { $_ -ne '' })
+      if ($current -notcontains 'Default Distribution: {{ windows_manage_wsl_distribution_default }}') {
+        $Ansible.Changed = $true
+        if ('{{ ansible_check_mode }}' -eq 'true') { Exit 0 }
+        $default = "{{ windows_manage_wsl_distribution_default }}"
+        $result = (wsl.exe --set-default $default) -replace '\x00', '' | ? { $_ -ne '' } | Out-String
+        if ($LASTEXITCODE -ne 0) {
+          $Ansible.Result = "Failed to set default distribution: $result"
+          $Ansible.Failed = $true
+          Exit 1
+        }
+      }
+  when:
+    - windows_manage_wsl_distribution_default is truthy
+    - windows_manage_wsl__install is not changed or
+      windows_manage_wsl_reboot | bool
+
+- name: Update installed WSL distributions
+  environment:
+    WSL_UTF8: "1"
+  check_mode: false
+  ansible.windows.win_powershell:
+    error_action: silently_continue
+    script: |
+      $Ansible.Changed = $false
+      $distro = '{{ item }}'
+      $mappings = '{{ windows_manage_wsl_distribution_update_commands | to_json }}' | ConvertFrom-Json
+      $commands = @()
+      foreach ($mapping in $mappings.PSObject.Properties) {
+        foreach ($pattern in $mapping.Value.patterns) {
+          if ($distro -like $pattern) {
+            $commands = $mapping.Value.commands
+            break
+          }
+        }
+        if ($commands) { break }
+      }
+      foreach ($cmd in $commands) {
+        $result = (wsl.exe --distribution "$distro" --user root --exec ($cmd -split ' ')) -replace '\x00', '' | ? { $_ -ne '' }
+        $rc = $LASTEXITCODE
+        if ($cmd -ne 'apt-get update' -and $cmd -ne '/bin/true' -and $result -join ',' -notmatch ',0 upgraded|nothing to do') {
+          $Ansible.Changed = $true
+        }
+        if ($rc -ne 0) {
+          $Ansible.Result = "Failed to update $distro`: $result"
+          $Ansible.Failed = $true
+          Exit 1
+        }
+      }
+  loop: "{{ windows_manage_wsl_distributions_update }}"
+  when:
+    - windows_manage_wsl__install is not changed or
+      windows_manage_wsl_reboot | bool

--- a/roles/windows_manage_wsl/tasks/main.yml
+++ b/roles/windows_manage_wsl/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Enable WSL
+  ansible.builtin.include_tasks: enable.yml
+  when: windows_manage_wsl_enable | bool
+
+- name: Disable WSL
+  ansible.builtin.include_tasks: disable.yml
+  when: not windows_manage_wsl_enable | bool

--- a/roles/windows_manage_wsl/templates/disable_cgroup_v1
+++ b/roles/windows_manage_wsl/templates/disable_cgroup_v1
@@ -1,0 +1,2 @@
+[wsl2]
+kernelCommandLine = cgroup_no_v1=all

--- a/tests/integration/targets/windows_ops_test_windows_manage_wsl/aliases
+++ b/tests/integration/targets/windows_ops_test_windows_manage_wsl/aliases
@@ -1,0 +1,2 @@
+windows
+infra/windows

--- a/tests/integration/targets/windows_ops_test_windows_manage_wsl/defaults/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_wsl/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Installing WSL is heavy: it requires a reboot and network access and cannot be
+# cleanly undone on a shared test image. By default this test only exercises the
+# role in check mode (safe, read-only) to validate its logic without changing the
+# host. Set to true on a disposable host to perform a real install/uninstall.
+windows_ops_test_wsl_full: false

--- a/tests/integration/targets/windows_ops_test_windows_manage_wsl/tasks/main.yml
+++ b/tests/integration/targets/windows_ops_test_windows_manage_wsl/tasks/main.yml
@@ -1,0 +1,76 @@
+---
+- name: Test WSL configuration
+  block:
+    # -- Safe path: exercise the role in check mode (no host changes) --
+    # The role's wsl.exe read tasks run read-only; install/uninstall steps
+    # detect check mode via ansible_check_mode and exit before making changes.
+    - name: Run role in check mode (enable)
+      check_mode: true
+      block:
+        - name: Include role in check mode
+          ansible.builtin.include_role:
+            name: infra.windows_ops.windows_manage_wsl
+          vars:
+            windows_manage_wsl_enable: true
+            windows_manage_wsl_update: false
+            windows_manage_wsl_reboot: false
+
+    - name: Record that the check-mode run completed
+      ansible.builtin.set_fact:
+        windows_manage_wsl__check_ok: true
+
+    - name: Run role again in check mode (idempotency smoke test)
+      check_mode: true
+      block:
+        - name: Include role in check mode again
+          ansible.builtin.include_role:
+            name: infra.windows_ops.windows_manage_wsl
+          vars:
+            windows_manage_wsl_enable: true
+            windows_manage_wsl_update: false
+            windows_manage_wsl_reboot: false
+
+    - name: Assert the role ran cleanly in check mode
+      ansible.builtin.assert:
+        that:
+          - windows_manage_wsl__check_ok | default(false) | bool
+        fail_msg: "windows_manage_wsl did not complete cleanly in check mode"
+        quiet: true
+
+    # -- Optional real install/uninstall (disposable hosts only) --
+    - name: Full install/uninstall cycle
+      when: windows_ops_test_wsl_full | bool
+      block:
+        - name: Install WSL
+          ansible.builtin.include_role:
+            name: infra.windows_ops.windows_manage_wsl
+          vars:
+            windows_manage_wsl_enable: true
+            windows_manage_wsl_reboot: true
+
+        - name: Query WSL status
+          environment:
+            WSL_UTF8: "1"
+          check_mode: false
+          ansible.windows.win_powershell:
+            error_action: silently_continue
+            script: |
+              $Ansible.Changed = $false
+              $Ansible.Result = ((wsl.exe --status) -replace '\x00', '' | Out-String)
+          register: windows_manage_wsl__status
+
+        - name: Assert WSL reports a status
+          ansible.builtin.assert:
+            that:
+              - windows_manage_wsl__status.result | trim | length > 0
+            fail_msg: "WSL did not report a status after install"
+            quiet: true
+
+  always:
+    - name: Restore host by uninstalling WSL
+      when: windows_ops_test_wsl_full | bool
+      ansible.builtin.include_role:
+        name: infra.windows_ops.windows_manage_wsl
+      vars:
+        windows_manage_wsl_enable: false
+        windows_manage_wsl_reboot: true


### PR DESCRIPTION
##### SUMMARY
New `windows_manage_wsl` role, migrated from the upstream `wsl_configuration` role in myllynen/windows-ansible-roles. Enables/configures Windows Subsystem for Linux (feature enablement via `win_optional_feature`, `.wslconfig` via `win_template`, and `wsl.exe` operations).

Part of the ACA-2792 Windows content migration (Batch 7 — Maintenance/Config). Ships with the role (defaults, argument_specs, README), an AAP automation pattern (setup, playbook, survey, execution environment), an idempotent integration test (`windows_ops_test_windows_manage_wsl`), and a changelog fragment.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
windows_manage_wsl

##### ADDITIONAL INFORMATION
Migration standards applied: public vars use the `windows_manage_wsl_` prefix (validated in `meta/argument_specs.yml`); internal vars use the `windows_manage_wsl__` prefix; input validation relies on the argument spec (no defensive filtering); `assert` used for preconditions; dependencies limited to `ansible.windows`/`community.windows`. `win_powershell` retained for every `wsl.exe` operation (confirmed native gap), flagged with comments; native modules used for the feature and `.wslconfig` file. `ansible-lint --profile production` and `yamllint` pass clean.